### PR TITLE
Accept list as well as tuple in all() and filter() methods to prevent returning NoneType.

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -137,7 +137,7 @@ class Manager(object):
         response = data[u'Response']
         result = response.get(self.name, {})
 
-        if isinstance(result, tuple):
+        if isinstance(result, tuple) or isinstance(result, list):
             return result
 
         if isinstance(result, dict) and self.singular in result:


### PR DESCRIPTION
xero.manager.Manager.all() and Manager.filter() did not function correctly as the _get_results method expected a tuple but received a list. Corrected this method to look for list as well.

With the previous code you'd simply be given a NoneType.

Cheers
