### PR TITLE
fix UnicodeEncodeError for non-ascii data

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -151,7 +151,7 @@ class Manager(object):
             if response.status_code == 200:
                 if response.headers['content-type'] == 'application/pdf':
                     return response.text
-                dom = parseString(response.text)
+                dom = parseString(response.text.encode('utf-8'))
                 data = self.convert_to_dict(self.walk_dom(dom))
                 return self._get_results(data)
 


### PR DESCRIPTION
This fixes the UnicodeEncode error when loading `xero.contacts.all()` with non-ASCII data:

```
Traceback (most recent call last):
  File "test.py", line 10, in <module>
    print xero.contacts.all()
  File "/Users/shamrin/src/xero/pyxero/xero/manager.py", line 154, in wrapper
    dom = parseString(response.text)
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/minidom.py", line 1931, in parseString
    return expatbuilder.parseString(string)
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/expatbuilder.py", line 940, in parseString
    return builder.parseString(string)
  File "/usr/local/Cellar/python/2.7.5/Frameworks/Python.framework/Versions/2.7/lib/python2.7/xml/dom/expatbuilder.py", line 223, in parseString
    parser.Parse(string, True)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 13093: ordinal not in range(128)
```

(No tests for now because of #4)
