### PR TITLE
Support Xero's Guid datatype

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -16,6 +16,7 @@ class Manager(object):
     DATETIME_FIELDS = (u'UpdatedDateUTC', u'Updated', u'FullyPaidOnDate')
     DATE_FIELDS = (u'DueDate', u'Date')
     BOOLEAN_FIELDS = (u'IsSupplier', u'IsCustomer')
+    OTHER_DATATYPES = {u'ContactID':u'Guid', u'InvoiceID':u'Guid'}
 
     MULTI_LINES = (u'LineItem', u'Phone', u'Address', 'TaxRate')
     PLURAL_EXCEPTIONS = {'Addresse': 'Address'}
@@ -227,6 +228,11 @@ class Manager(object):
                 del kwargs['since']
 
             def get_filter_params():
+                # support strange datatypes like the Guid
+                last_key = key.split('_')[-1]
+                if last_key in self.OTHER_DATATYPES.keys():
+                    return '%s("%s")' % (str(self.OTHER_DATATYPES[last_key]),str(kwargs[key]))
+                
                 if key in self.BOOLEAN_FIELDS:
                     return 'true' if kwargs[key] else 'false'
                 elif key in self.DATETIME_FIELDS:


### PR DESCRIPTION
This change supports the Guid datatype for the ContactID and InvoiceID keys, allowing you to filter for (for example), all the invoices belonging to a particular contact.
