### PR TITLE
Add support for manual journals

### DIFF
--- a/xero/api.py
+++ b/xero/api.py
@@ -6,7 +6,7 @@ class Xero(object):
 
     OBJECT_LIST = (u'Contacts', u'Accounts', u'CreditNotes',
                    u'Currencies', u'Invoices', u'Items', u'Organisation',
-                   u'Payments', u'TaxRates', u'TrackingCategories')
+                   u'Payments', u'TaxRates', u'TrackingCategories', u'ManualJournals')
 
     def __init__(self, credentials):
         # Iterate through the list of objects we support, for


### PR DESCRIPTION
Simply add ManualJournals to OBJECT_LIST.

I had this patch lying around for ages in a fork of XeroPy. I've tested it and it seems to work absolutely fine (yay for good APIs).
