### PR TITLE
Users receipts expense claims

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,9 @@ This same API pattern exists for the following API objects:
 * ManualJournals
 * BankTransactions
 * BankTransfers
+* ExpenseClaims
+* Receipts
+* Users
 
 
 .. _Xero: http://developer.xero.com

--- a/examples/add_receipts.py
+++ b/examples/add_receipts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+
+"""Upload receipts to Xero from a CSV file"""
+
+# http://developer.xero.com/documentation/api/receipts/
+
+import argparse
+import csv
+import os.path
+import pickle
+import sys
+
+import webbrowser
+
+from config import xero_config
+
+from xero import Xero
+from xero.auth import PublicCredentials
+
+argp = argparse.ArgumentParser(description=__doc__)
+argp.add_argument('-i', '--input-file', dest='input_file', default='-', help='input file name')
+argp.add_argument('-c', '--credentials-file', dest='credentials_file', default='credentials.pickle', help='credentials file name')
+args = argp.parse_args()
+
+# Connect to Xero
+if os.path.isfile(args.credentials_file):
+    # Use cached credentials 
+    with open(args.credentials_file, 'r') as credentials_fh:
+        credentials_state = pickle.loads(credentials_fh.read())
+        credentials = PublicCredentials(**credentials_state)
+else:
+    credentials = PublicCredentials(xero_config['consumer_key'], xero_config['consumer_secret'])
+    print credentials.url
+    webbrowser.open(credentials.url)
+    verifier = raw_input('Enter auth code: ')
+    credentials.verify(verifier)
+    with open(args.credentials_file, 'w') as credentials_fh:
+        pickle.dump(credentials.state, credentials_fh)
+xero = Xero(credentials)
+
+# Get userids matching user email
+userids = {}
+users = xero.users.all()
+#print users
+for user in users:
+    userids[user['EmailAddress']] = user['UserID']
+
+# Get receipts and add them to Xero
+if args.input_file == '-':
+    in_fh = sys.stdin
+else:
+    in_fh = open(args.input_file, 'r')
+
+# Date,UserEmail,ContactName,Reference,Description,UnitAmount,AccountCode
+reader = csv.DictReader(in_fh, delimiter=',')
+receipts = []
+for i in reader:
+    #print i
+
+    user_email = i['UserEmail']
+    if user_email not in userids:
+        print "Unknown user: %s" % (user_email,)
+        continue
+    userid = userids[i['UserEmail']],
+
+    # TODO: Validate input data
+
+    data = {
+        'Date': i['Date'],
+        'Contact': {'Name': i['ContactName']},
+        'Reference': i['Reference'],
+        'LineItems': [
+            {'Description': i['Description'], 'UnitAmount': i['UnitAmount'], 'AccountCode': i['AccountCode']},
+        ],
+        'User': {'UserID': userids[i['UserEmail']]},
+    }
+    #print data
+    #xml = xero.receipts._prepare_data_for_save(data)
+    #print xml
+    receipts.append(data)
+
+#print receipts
+
+if receipts:
+    results = xero.receipts.put(receipts)
+    # import pprint
+    #pp = pprint.PrettyPrinter(depth=6)
+    #pp.pprint(results)

--- a/examples/add_receipts.py
+++ b/examples/add_receipts.py
@@ -12,7 +12,11 @@ import sys
 
 import webbrowser
 
-from config import xero_config
+#from config import xero_config
+xero_config = {
+    "consumer_key": "XXX",
+    "consumer_secret": "XXX",
+}
 
 from xero import Xero
 from xero.auth import PublicCredentials

--- a/examples/receipts.csv
+++ b/examples/receipts.csv
@@ -1,0 +1,4 @@
+Date,UserEmail,ContactName,Reference,Description,UnitAmount,AccountCode
+2014-09-01,jake@example.com,Taxi,,Taxi,9.50,429
+2014-09-02,jake@example.com,Bob's Diner,,Business meal,35.53,420
+

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -11,7 +11,6 @@ from xero import Xero
 from xero.manager import Manager
 from tests import mock_data
 
-
 class ManagerTest(unittest.TestCase):
     def test_serialization(self):
         "An invoice can be correctly serialized for a POST/PUT request"

--- a/xero/api.py
+++ b/xero/api.py
@@ -7,7 +7,9 @@ class Xero(object):
     OBJECT_LIST = (u'Contacts', u'Accounts', u'CreditNotes',
                    u'Currencies', u'Invoices', u'Items', u'Organisation',
                    u'Payments', u'TaxRates', u'TrackingCategories', u'ManualJournals',
-                   u'BankTransactions', u'BankTransfers')
+                   u'BankTransactions', u'BankTransfers', 
+                   u'Users', u'Receipts', u'ExpenseClaims',
+                   )
 
     def __init__(self, credentials):
         # Iterate through the list of objects we support, for

--- a/xero/manager.py
+++ b/xero/manager.py
@@ -8,7 +8,6 @@ from urlparse import parse_qs
 from .constants import XERO_API_URL
 from .exceptions import *
 
-
 def isplural(word):
     return word[-1].lower() == 's'
 
@@ -27,6 +26,7 @@ class Manager(object):
                    u'StartDate', u'EndDate',
                    u'PeriodLockDate', u'DateOfBirth',
                    u'OpeningBalanceDate',
+                   u'PaymentDueDate', u'ReportingDate',
                    )
     BOOLEAN_FIELDS = (u'IsSupplier', u'IsCustomer', u'IsDemoCompany',
                       u'PaysTax', u'IsAuthorisedToApproveTimesheets',
@@ -35,6 +35,7 @@ class Manager(object):
                       u'TaxFreeThresholdClaimed', u'HasSFSSDebt',
                       u'EligibleToReceiveLeaveLoading',
                       u'IsExemptFromTax', u'IsExemptFromSuper',
+                      u'IsSubscriber', u'HasAttachments',
                       )
     DECIMAL_FIELDS = (u'Hours', u'NumberOfUnit')
     INTEGER_FIELDS = (u'FinancialYearEndDay', u'FinancialYearEndMonth')


### PR DESCRIPTION
I added support for Users, Receipts and Expense claims. I just added the necessary configuration information to the API and manager files. I also added an example script which creates receipts based on a CSV file. 

In xero/manager.py there is a list of DECIMAL_FIELDS. Should this be used for the money-related fields, e.g. Total. If so, it breaks the comparison test in tests/manager.py. 