### PR TITLE
add 4 decimal place support for unit prices

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -117,3 +117,24 @@ class ManagerTest(unittest.TestCase):
 
         self.assertEqual(params,
             {'where': 'Contact.ContactID==Guid("3e776c4b-ea9e-4bb1-96be-6b0c7a71a37f")'})
+
+    def test_unit4dps(self):
+        """The manager should add a query param of unitdp iff enabled"""
+
+        credentials = Mock(base_url="")
+
+        # test 4dps is disabled by default
+        manager = Manager('contacts', credentials)
+        uri, params, method, body, headers, singleobject = manager._filter()
+        self.assertEqual(params, {}, "test 4dps not enabled by default")
+
+        # test 4dps is enabled by default
+        manager = Manager('contacts', credentials, unit_price_4dps=True)
+        uri, params, method, body, headers, singleobject = manager._filter()
+        self.assertEqual(params, {"unitdp": 4}, "test 4dps can be enabled explicitly")
+
+        # test 4dps can be disable explicitly
+        manager = Manager('contacts', credentials, unit_price_4dps=False)
+        uri, params, method, body, headers, singleobject = manager._filter()
+        self.assertEqual(params, {}, "test 4dps can be disabled explicitly")
+

--- a/xero/api.py
+++ b/xero/api.py
@@ -31,13 +31,13 @@ class Xero(object):
       "Users",
     )
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, unit_price_4dps=False):
         # Iterate through the list of objects we support, for
         # each of them create an attribute on our self that is
         # the lowercase name of the object and attach it to an
         # instance of a Manager object to operate on it
         for name in self.OBJECT_LIST:
-            setattr(self, name.lower(), Manager(name, credentials))
+            setattr(self, name.lower(), Manager(name, credentials, unit_price_4dps))
         
         setattr(self, "filesAPI", Files(credentials))
         

--- a/xero/manager.py
+++ b/xero/manager.py
@@ -69,10 +69,11 @@ class Manager(object):
 
     NO_SEND_FIELDS = ('UpdatedDateUTC',)
 
-    def __init__(self, name, credentials):
+    def __init__(self, name, credentials, unit_price_4dps=False):
         self.credentials = credentials
         self.name = name
         self.base_url = credentials.base_url + XERO_API_URL
+        self.extra_params = {"unitdp": 4} if unit_price_4dps else {}
 
         # setup our singular variants of the name
         # only if the name ends in 's'
@@ -287,7 +288,8 @@ class Manager(object):
 
     def _get(self, id, headers=None):
         uri = '/'.join([self.base_url, self.name, id])
-        return uri, {}, 'get', None, headers, True
+        params = self.extra_params.copy()
+        return uri, params, 'get', None, headers, True
 
     def _get_attachments(self, id):
         """Retrieve a list of attachments associated with this Xero object."""
@@ -314,10 +316,9 @@ class Manager(object):
     def save_or_put(self, data, method='post', headers=None, summarize_errors=True):
         uri = '/'.join([self.base_url, self.name])
         body = {'xml': self._prepare_data_for_save(data)}
-        if summarize_errors:
-            params = {}
-        else:
-            params = {'summarizeErrors': 'false'}
+        params = self.extra_params.copy()
+        if not summarize_errors:
+            params['summarizeErrors'] = 'false'
         return uri, params, method, body, headers, False
 
     def _save(self, data):
@@ -346,7 +347,7 @@ class Manager(object):
         return {'If-Modified-Since': val}
 
     def _filter(self, **kwargs):
-        params = {}
+        params = self.extra_params.copy()
         headers = None
         uri = '/'.join([self.base_url, self.name])
         if kwargs:


### PR DESCRIPTION
This PR provides a way of adding the ?unitdp=4 query param to a request as per the Xero docs:

  http://developer.xero.com/documentation/advanced-docs/rounding-in-xero/#title2

It defaults to off for backwards compatibility.

You can turn it on when constructing the Xero object or a Manager object by passing the parameter unit_price_4dps=True to the constructor.