### PR TITLE
Allow passing GET parameters to get(..) methods

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -242,7 +242,7 @@ class ManagerTest(unittest.TestCase):
         uri, params, method, body, headers, singleobject = manager._get(
             "ProfitAndLoss", params=passed_params
         )
-        self.assertEqual(passed_params, params, "test params can be set")
+        self.assertEqual(params, passed_params, "test params can be set")
 
         # test params respect, but can override, existing configuration
         manager = Manager("reports", credentials, unit_price_4dps=True)

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -222,3 +222,35 @@ class ManagerTest(unittest.TestCase):
         manager = Manager('contacts', credentials, unit_price_4dps=False)
         uri, params, method, body, headers, singleobject = manager._filter()
         self.assertEqual(params, {}, "test 4dps can be disabled explicitly")
+
+    def test_get_params(self):
+        """The 'get' methods should pass GET parameters if provided.
+        """
+
+        credentials = Mock(base_url="")
+        manager = Manager("reports", credentials)
+
+        # test no parameters or headers sent by default
+        uri, params, method, body, headers, singleobject = manager._get("ProfitAndLoss")
+        self.assertEqual(params, {}, "test params not sent by default")
+
+        # test params can be provided
+        passed_params = {
+            "fromDate": "2015-01-01",
+            "toDate": "2015-01-15",
+        }
+        uri, params, method, body, headers, singleobject = manager._get(
+            "ProfitAndLoss", params=passed_params
+        )
+        self.assertEqual(passed_params, params, "test params can be set")
+
+        # test params respect, but can override, existing configuration
+        manager = Manager("reports", credentials, unit_price_4dps=True)
+        uri, params, method, body, headers, singleobject = manager._get(
+            "ProfitAndLoss", params=passed_params
+        )
+        self.assertEqual(params, {
+            "fromDate": "2015-01-01",
+            "toDate": "2015-01-15",
+            "unitdp": 4,
+        }, "test params respects existing values")

--- a/xero/manager.py
+++ b/xero/manager.py
@@ -216,10 +216,11 @@ class Manager(object):
 
         return wrapper
 
-    def _get(self, id, headers=None):
+    def _get(self, id, headers=None, params=None):
         uri = '/'.join([self.base_url, self.name, id])
-        params = self.extra_params.copy()
-        return uri, params, 'get', None, headers, True
+        uri_params = self.extra_params.copy()
+        uri_params.update(params if params else {})
+        return uri, uri_params, 'get', None, headers, True
 
     def _get_attachments(self, id):
         """Retrieve a list of attachments associated with this Xero object."""


### PR DESCRIPTION
Here's my suggestion for the allowing reports to be used in full (#81).

The tests have been successfully ran on py27/33/34. The tests test_serializer and test_serializer_nested_singular failed (before and after change) on py26 but all other tests passed.
