### PR TITLE
Added support for Contact Groups

### DIFF
--- a/xero/api.py
+++ b/xero/api.py
@@ -12,6 +12,7 @@ class Xero(object):
         "BankTransactions",
         "BankTransfers",
         "BrandingThemes",
+        "ContactGroups",
         "Contacts",
         "CreditNotes",
         "Currencies",

--- a/xero/utils.py
+++ b/xero/utils.py
@@ -16,6 +16,7 @@ OBJECT_NAMES = {
     "BankTransactions": "BankTransaction",
     "BankTransfers": "BankTransfer",
     "BrandingThemes": "BrandingTheme",
+    "ContactGroups": "ContactGroup",
     "Contacts": "Contact",
     "CreditNotes": "CreditNote",
     "Currencies": "Currency",


### PR DESCRIPTION
Pull request for #84.

I've also tested this the following doctest - ran against a reset demo company - and it works fine.

```python
>>> import pprint
>>> import xero
>>> import xero.auth


>>> pp = pprint.PrettyPrinter(indent=4)

>>> with open('x509/privatekey.pem') as pkf:
...     rsa_key = pkf.read()

>>> with open('x509/consumer_key.txt') as ckf:
...     consumer_key = ckf.read()

>>> credentials = xero.auth.PrivateCredentials(consumer_key, rsa_key)
>>> client = xero.Xero(credentials)

>>> contactgroups = client.contactgroups.all()

>>> pp.pprint(contactgroups)
[   {   u'ContactGroupID': u'...',
        u'Contacts': [],
        u'HasValidationErrors': False,
        u'Name': u'Contractors',
        u'Status': u'ACTIVE'},
    {   u'ContactGroupID': u'...',
        u'Contacts': [],
        u'HasValidationErrors': False,
        u'Name': u'Support Clients (monthly)',
        u'Status': u'ACTIVE'}]

>>> client.contactgroups.put({'Name': 'TestGroup'})
[...

>>> contactgroups = client.contactgroups.all()

>>> pp.pprint(contactgroups)
[   {   u'ContactGroupID': u'...',
        u'Contacts': [],
        u'HasValidationErrors': False,
        u'Name': u'Contractors',
        u'Status': u'ACTIVE'},
    {   u'ContactGroupID': u'...',
        u'Contacts': [],
        u'HasValidationErrors': False,
        u'Name': u'Support Clients (monthly)',
        u'Status': u'ACTIVE'},
    {   u'ContactGroupID': u'...',
        u'Contacts': [],
        u'HasValidationErrors': False,
        u'Name': u'TestGroup',
        u'Status': u'ACTIVE'}]
```