### PR TITLE
Fix comment in README example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ For example, to deal with contacts::
 # Create a new object
 >>> xero.contacts.put({...contact info...})
 
-# Create a new object
+# Create multiple new objects
 >>> xero.contacts.put([{...contact info...}, {...contact info...}, {...contact info...}])
 
 # Save an update to an existing object


### PR DESCRIPTION
The comment says "Create a new object", but the code sample it comments is clearly intended to demonstrate creating multiple new objects.