### PR TITLE
Fix XeroBadRequest without 'Elements'

### DIFF
--- a/xero/exceptions.py
+++ b/xero/exceptions.py
@@ -20,10 +20,13 @@ class XeroBadRequest(XeroException):
         if response.headers['content-type'].startswith('application/json'):
             data = json.loads(response.text)
             msg = "%s: %s" % (data['Type'], data['Message'])
-            self.errors = [err['Message']
-                for elem in data['Elements']
-                for err in elem['ValidationErrors']
-            ]
+            try:
+                self.errors = [err['Message']
+                    for elem in data['Elements']
+                    for err in elem['ValidationErrors']
+                ]
+            except KeyError:
+                self.errors = [data['Message']]
             self.problem = self.errors[0]
             super(XeroBadRequest, self).__init__(response, msg=msg)
 


### PR DESCRIPTION
There are circumstances where the returned data may not have an 'Elements' key.  In such cases, the upstream code bombs out and fails to report any useful error detail, see freakboy3742/pyxero#78.

This commit catches any KeyError in the problematic code expression, and stores the entire 'Message' value in the errors list as a fallback.