### PR TITLE
Catch KeyErrors in _parse_api_response

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -147,7 +147,10 @@ class Manager(object):
     def _parse_api_response(self, response, resource_name):
         data = json.loads(response.text, object_hook=json_load_object_hook)
         assert data['Status'] == 'OK', "Expected the API to say OK but received %s" % data['Status']
-        return data[resource_name]
+        try:
+            return data[resource_name]
+        except KeyError:
+            return data
 
     def _get_data(self, func):
         """ This is the decorator for our DECORATED_METHODS.


### PR DESCRIPTION
The response to an Attachment request is not structured in the same way as other requests that pass through Manager.  In particular, it does not have a key matching 'resource_name' at its top level.  This causes _parse_api_response to blow up unnecessarily.

It may be possible to do this in a more targeted way, by detecting the structure of an Attachment response, and unpacking it as appropriate, but this is a) better than nothing, and b) will also work for any other unorthodox response types that happen along in future.

Fixes freakboy3742/pyxero#94