### PR TITLE
add explicit user_agent setting for xero requests

### DIFF
--- a/xero/api.py
+++ b/xero/api.py
@@ -34,13 +34,14 @@ class Xero(object):
         "Users",
     )
 
-    def __init__(self, credentials, unit_price_4dps=False):
+    def __init__(self, credentials, unit_price_4dps=False, user_agent=None):
         # Iterate through the list of objects we support, for
         # each of them create an attribute on our self that is
         # the lowercase name of the object and attach it to an
         # instance of a Manager object to operate on it
         for name in self.OBJECT_LIST:
-            setattr(self, name.lower(), Manager(name, credentials, unit_price_4dps))
+            setattr(self, name.lower(), Manager(name, credentials, unit_price_4dps,
+                                                user_agent))
 
         setattr(self, "filesAPI", Files(credentials))
 


### PR DESCRIPTION
Xero partner integration required send partner related `User-Agent`, but look like that now it required override whole `Manager._get_data.wrapper`. This PR allow set custom `User-Agent` for this case.