### PR TITLE
Add 'HasValidationErrors' to the NO_SEND_FIELDS collection

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -74,6 +74,7 @@ class Manager(object):
     )
     NO_SEND_FIELDS = (
         'UpdatedDateUTC',
+        'HasValidationErrors',
     )
     OPERATOR_MAPPINGS = {
         'gt': '>',


### PR DESCRIPTION
Relates to https://github.com/freakboy3742/pyxero/issues/103 and https://community.xero.com/developer/discussion/12184472

If you get a contact (and probably other things), edit the dict and send it straight back, the Xero API will throw a bad request exception with the message "PostDataInvalidException: The element 'HasValidationErrors' was not recognised. Ensure the element name has the correct case and that there are no duplicate elements of the same name."