### PR TITLE
Added support for includeArchived parameter.

### DIFF
--- a/xero/manager.py
+++ b/xero/manager.py
@@ -339,7 +339,7 @@ class Manager(object):
                 )
 
             # Move any known parameter names to the query string
-            KNOWN_PARAMETERS = ['order', 'offset', 'page']
+            KNOWN_PARAMETERS = ['order', 'offset', 'page', 'includeArchived']
             for param in KNOWN_PARAMETERS:
                 if param in kwargs:
                     params[param] = kwargs.pop(param)


### PR DESCRIPTION
This commit allows support for including archived items in the results sets.  This is currently a feature in the Xero API for contacts (http://developer.xero.com/documentation/api/contacts/) and tracking categories (http://developer.xero.com/documentation/api/tracking-categories/).

Usage:

    # Get contacts, including archived contacts
    >>> xero.contacts.filter(includeArchived=True)
   