### PR TITLE
Add missing import; address deprecation warning; cull import *

### DIFF
--- a/tests/auth.py
+++ b/tests/auth.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from mock import patch, Mock
 
 from xero.auth import PublicCredentials, PartnerCredentials
-from xero.exceptions import *
+from xero.exceptions import XeroException, XeroNotVerified, XeroUnauthorized
 
 
 class PublicCredentialsTest(unittest.TestCase):

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -113,7 +113,7 @@ class PublicCredentialsTest(unittest.TestCase):
             consumer_secret='secret'
         )
 
-        self.assertEquals(credentials.url, 'https://api.xero.com/oauth/Authorize?oauth_token=token')
+        self.assertEqual(credentials.url, 'https://api.xero.com/oauth/Authorize?oauth_token=token')
 
     @patch('requests.post')
     def test_verify(self, r_post):

--- a/tests/exceptions.py
+++ b/tests/exceptions.py
@@ -6,8 +6,12 @@ from datetime import date
 from mock import Mock, patch
 
 from xero import Xero
-from xero.exceptions import *
-from tests import mock_data
+from xero.exceptions import (
+    XeroBadRequest, XeroForbidden, XeroInternalError, XeroNotAvailable,
+    XeroNotFound, XeroNotImplemented, XeroRateLimitExceeded, XeroUnauthorized
+)
+
+from . import mock_data
 
 
 class ExceptionsTest(unittest.TestCase):

--- a/tests/mock_data.py
+++ b/tests/mock_data.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+
 # exceptions.py
 
 bad_request_text = """<ApiException xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,9 @@
 from __future__ import unicode_literals
 
-""" Tests of the utils module.
-"""
-try:
-    # Try importing from unittest2 first. This is primarily for Py2.6 support.
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+""" Tests of the utils module. """
 import datetime
+import unittest
+
 import xero.utils
 
 

--- a/xero/api.py
+++ b/xero/api.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
-from .manager import Manager
+
 from .filesmanager import FilesManager
+from .manager import Manager
 
 
 class Xero(object):

--- a/xero/auth.py
+++ b/xero/auth.py
@@ -1,14 +1,23 @@
 from __future__ import unicode_literals
+
 import datetime
 import requests
+
+from oauthlib.oauth1 import (
+    SIGNATURE_RSA, SIGNATURE_TYPE_AUTH_HEADER, SIGNATURE_HMAC
+)
 from requests_oauthlib import OAuth1
-from oauthlib.oauth1 import (SIGNATURE_RSA, SIGNATURE_TYPE_AUTH_HEADER,
-                             SIGNATURE_HMAC)
 from six.moves.urllib.parse import urlencode, parse_qs
 
-from .constants import (XERO_BASE_URL, XERO_PARTNER_BASE_URL,
-                        REQUEST_TOKEN_URL, AUTHORIZE_URL, ACCESS_TOKEN_URL)
-from .exceptions import *
+from .constants import (
+    XERO_BASE_URL, XERO_PARTNER_BASE_URL,
+    REQUEST_TOKEN_URL, AUTHORIZE_URL, ACCESS_TOKEN_URL
+)
+from .exceptions import (
+    XeroBadRequest, XeroException, XeroExceptionUnknown, XeroForbidden,
+    XeroInternalError, XeroNotAvailable, XeroNotFound, XeroNotImplemented,
+    XeroNotVerified, XeroRateLimitExceeded, XeroUnauthorized
+)
 
 
 OAUTH_EXPIRY_SECONDS = 3600 # Default unless a response reports differently

--- a/xero/exceptions.py
+++ b/xero/exceptions.py
@@ -1,6 +1,7 @@
+import json
+
 from six.moves.urllib.parse import parse_qs
 from xml.dom.minidom import parseString
-import json
 
 
 class XeroException(Exception):

--- a/xero/filesmanager.py
+++ b/xero/filesmanager.py
@@ -1,11 +1,16 @@
 from __future__ import unicode_literals
 
+import os
 import requests
 
 from six.moves.urllib.parse import parse_qs
 
 from .constants import XERO_FILES_URL
-from .exceptions import *
+from .exceptions import (
+    XeroBadRequest, XeroExceptionUnknown, XeroForbidden, XeroInternalError,
+    XeroNotAvailable, XeroNotFound, XeroNotImplemented, XeroRateLimitExceeded,
+    XeroUnauthorized, XeroUnsupportedMediaType
+)
 
 
 class FilesManager(object):

--- a/xero/manager.py
+++ b/xero/manager.py
@@ -1,15 +1,19 @@
 from __future__ import unicode_literals
 
+import json
 import requests
 import six
-import json
 
-from xml.etree.ElementTree import tostring, SubElement, Element
 from datetime import datetime
 from six.moves.urllib.parse import parse_qs
+from xml.etree.ElementTree import tostring, SubElement, Element
 
 from .constants import XERO_API_URL
-from .exceptions import *
+from .exceptions import (
+    XeroBadRequest, XeroExceptionUnknown, XeroForbidden, XeroInternalError,
+    XeroNotAvailable, XeroNotFound, XeroNotImplemented, XeroRateLimitExceeded,
+    XeroUnauthorized
+)
 from .utils import singular, isplural, json_load_object_hook
 
 


### PR DESCRIPTION
Import * should never be used; it was masking the fact there was an import missing.