### PR TITLE
Allow raw XML to be passed to PUT/POST methods.

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -245,19 +245,23 @@ class BaseManager(object):
         file.write(data)
         return len(data)
 
-    def save_or_put(self, data, method='post', headers=None, summarize_errors=True):
+    def save_or_put(self, data, is_raw_xml=False, method='post', headers=None, summarize_errors=True):
         uri = '/'.join([self.base_url, self.name])
-        body = {'xml': self._prepare_data_for_save(data)}
+        body = None
+        if is_raw_xml:
+            body = {'xml': data}
+        else:
+            body = {'xml': self._prepare_data_for_save(data)}
         params = self.extra_params.copy()
         if not summarize_errors:
             params['summarizeErrors'] = 'false'
         return uri, params, method, body, headers, False
 
-    def _save(self, data):
-        return self.save_or_put(data, method='post')
+    def _save(self, data, is_raw_xml=False):
+        return self.save_or_put(data, method='post', is_raw_xml=is_raw_xml)
 
-    def _put(self, data, summarize_errors=True):
-        return self.save_or_put(data, method='put', summarize_errors=summarize_errors)
+    def _put(self, data, summarize_errors=True, is_raw_xml=False):
+        return self.save_or_put(data, method='put', summarize_errors=summarize_errors, is_raw_xml=is_raw_xml)
 
     def _put_attachment_data(self, id, filename, data, content_type, include_online=False):
         """Upload an attachment to the Xero object."""


### PR DESCRIPTION
I'm converting an existing PHP implementation over to pyxero. With my current setup, I already have raw XML packets to be sent across to Xero in the PUT/POST API calls. pyxero seems to only allow dicts to be passed in to the PUT/POST methods, and rewrites the dict objects in to XML. 

This pull request allows the developer to submit raw XML in place of a dict object. Not sure how useful this will be to others, but coming from an existing implementation, it has been useful for me.