### PR TITLE
Added ShowOnCashBasisReports as a Boolean field

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -63,6 +63,7 @@ class BaseManager(object):
         'SentToContact',
         'IsSubscriber',
         'HasAttachments',
+        'ShowOnCashBasisReports',
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
ShowOnCashBasisReports is a Boolean field used in Reports and needs to be cleaned before being sent back to Xero.