### PR TITLE
Add IncludeInEmails to BOOLEAN_FIELDS

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -64,6 +64,7 @@ class BaseManager(object):
         'IsSubscriber',
         'HasAttachments',
         'ShowOnCashBasisReports',
+        'IncludeInEmails',
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
Found this was needed when saving a contact with an additional ContactPerson.

http://developer.xero.com/documentation/api/contacts/#title2