### PR TITLE
datetime format is incorrect

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -76,7 +76,7 @@ class ManagerTest(unittest.TestCase):
             <Name>Basket Case</Name>
           </Contact>
           <Reference>ABAS 123</Reference>
-          <Date>2015-06-06 16:25:02.711109</Date>
+          <Date>2015-06-06T16:25:02</Date>
           <LineAmountTypes>Exclusive</LineAmountTypes>
           <LineItems>
             <LineItem>
@@ -98,7 +98,7 @@ class ManagerTest(unittest.TestCase):
             </LineItem>
           </LineItems>
           <Type>ACCREC</Type>
-          <DueDate>2015-07-06 16:25:02.711136</DueDate>
+          <DueDate>2015-07-06T16:25:02</DueDate>
         </Invoice>
         """
 
@@ -208,7 +208,7 @@ class ManagerTest(unittest.TestCase):
             <Status>DRAFT</Status>
             <Contact><Name>Basket Case</Name></Contact>
             <Reference>ABAS 123</Reference>
-            <Date>2015-06-06 16:25:02.711109</Date>
+            <Date>2015-06-06T16:25:02</Date>
             <LineAmountTypes>Exclusive</LineAmountTypes>
             <LineItems>
               <LineItem>
@@ -216,7 +216,7 @@ class ManagerTest(unittest.TestCase):
               </LineItem>
             </LineItems>
             <Type>ACCREC</Type>
-            <DueDate>2015-07-06 16:25:02.711136</DueDate>
+            <DueDate>2015-07-06T16:25:02</DueDate>
         """
 
         self.assertXMLEqual(

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -126,6 +126,8 @@ class BaseManager(object):
             else:
                 if key in self.BOOLEAN_FIELDS:
                     val = 'true' if sub_data else 'false'
+                elif key in self.DATE_FIELDS:
+                    val = sub_data.strftime('%Y-%m-%dT%H:%M:%S')
                 else:
                     val = six.text_type(sub_data)
                 elm.text = val


### PR DESCRIPTION
Please check out: https://app.xero.com/Preview/invoices/PUT, or the below XML sample taken from there, and notice that the format of the dates is: `2015-06-06T16:25:02` not `2015-06-06 16:25:02.711109`. This change updates the `basemanager` to use this format, and fixes tests to reflect this requirement.

XML from Xero API example:

`<Invoices>
  <Invoice>
    <Type>ACCREC</Type>
    <Contact>
      <Name>Martin Hudson</Name>
    </Contact>
    <Date>2016-02-02T00:00:00</Date>
    <DueDate>2016-02-09T00:00:00</DueDate>
    <LineAmountTypes>Exclusive</LineAmountTypes>
    <LineItems>
      <LineItem>
        <Description>Monthly rental for property at 56a Wilkins Avenue</Description>
        <Quantity>4.3400</Quantity>
        <UnitAmount>395.00</UnitAmount>
        <AccountCode>200</AccountCode>
      </LineItem>
    </LineItems>
  </Invoice>
</Invoices>`