### PR TITLE
Purchase orders endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ This same API pattern exists for the following API objects:
 * Overpayments
 * Payments
 * Prepayments
+* Purchase Orders
 * Receipts
 * RepeatingInvoices
 * Reports

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -131,7 +131,7 @@ class PublicCredentialsTest(unittest.TestCase):
             scope="payroll.endpoint"
         )
 
-        self.assertEqual(credentials.url, 'https://api.xero.com/oauth/Authorize?scope=payroll.endpoint&oauth_token=token')
+        self.assertIn('scope=payroll.endpoint', credentials.url)
 
     @patch('requests.post')
     def test_verify(self, r_post):

--- a/tests/auth.py
+++ b/tests/auth.py
@@ -18,7 +18,8 @@ class PublicCredentialsTest(unittest.TestCase):
 
         credentials = PublicCredentials(
             consumer_key='key',
-            consumer_secret='secret'
+            consumer_secret='secret',
+            scope='payroll.endpoint'
         )
 
         # A HTTP request was made
@@ -35,7 +36,8 @@ class PublicCredentialsTest(unittest.TestCase):
             'consumer_secret': 'secret',
             'oauth_token': 'token',
             'oauth_token_secret': 'token_secret',
-            'verified': False
+            'verified': False,
+            'scope': 'payroll.endpoint'
         })
 
     @patch('requests.post')
@@ -114,6 +116,22 @@ class PublicCredentialsTest(unittest.TestCase):
         )
 
         self.assertEqual(credentials.url, 'https://api.xero.com/oauth/Authorize?oauth_token=token')
+
+    @patch('requests.post')
+    def test_url_with_scope(self, r_post):
+        "The request token URL includes the scope parameter"
+        r_post.return_value = Mock(
+            status_code=200,
+            text='oauth_token=token&oauth_token_secret=token_secret'
+        )
+
+        credentials = PublicCredentials(
+            consumer_key='key',
+            consumer_secret='secret',
+            scope="payroll.endpoint"
+        )
+
+        self.assertEqual(credentials.url, 'https://api.xero.com/oauth/Authorize?scope=payroll.endpoint&oauth_token=token')
 
     @patch('requests.post')
     def test_verify(self, r_post):
@@ -212,7 +230,8 @@ class PartnerCredentialsTest(unittest.TestCase):
             consumer_key='key',
             consumer_secret='secret',
             rsa_key='abc',
-            client_cert=('/fake/path', '/fake/otherpath')
+            client_cert=('/fake/path', '/fake/otherpath'),
+            scope='payroll.endpoint'
         )
 
         # A HTTP request was made
@@ -229,7 +248,8 @@ class PartnerCredentialsTest(unittest.TestCase):
             'consumer_secret': 'secret',
             'oauth_token': 'token',
             'oauth_token_secret': 'token_secret',
-            'verified': False
+            'verified': False,
+            'scope': 'payroll.endpoint'
         })
 
     @patch('requests.post')

--- a/xero/api.py
+++ b/xero/api.py
@@ -28,6 +28,7 @@ class Xero(object):
         "Overpayments",
         "Payments",
         "Prepayments",
+        "PurchaseOrders",
         "Receipts",
         "RepeatingInvoices",
         "Reports",

--- a/xero/auth.py
+++ b/xero/auth.py
@@ -98,7 +98,8 @@ class PublicCredentials(object):
     def __init__(self, consumer_key, consumer_secret,
                  callback_uri=None, verified=False,
                  oauth_token=None, oauth_token_secret=None,
-                 oauth_expires_at=None, oauth_authorization_expires_at=None):
+                 oauth_expires_at=None, oauth_authorization_expires_at=None,
+                 scope=None):
         """Construct the auth instance.
 
         Must provide the consumer key and secret.
@@ -113,6 +114,7 @@ class PublicCredentials(object):
         self._oauth = None
         self.oauth_expires_at = oauth_expires_at
         self.oauth_authorization_expires_at = oauth_authorization_expires_at
+        self.scope = scope
 
         self.base_url = XERO_BASE_URL
         self._signature_method = SIGNATURE_HMAC
@@ -245,7 +247,7 @@ class PublicCredentials(object):
                 'consumer_key', 'consumer_secret', 'callback_uri',
                 'verified', 'oauth_token', 'oauth_token_secret',
                 'oauth_session_handle', 'oauth_expires_at',
-                'oauth_authorization_expires_at'
+                'oauth_authorization_expires_at', 'scope'
             )
             if getattr(self, attr) is not None
         )
@@ -274,8 +276,13 @@ class PublicCredentials(object):
     def url(self):
         "Returns the URL that can be visited to obtain a verifier code"
         # The authorize url is always api.xero.com
+        query_string = {'oauth_token': self.oauth_token}
+
+        if self.scope:
+            query_string['scope'] = self.scope
+
         url = XERO_BASE_URL + AUTHORIZE_URL + '?' + \
-              urlencode({'oauth_token': self.oauth_token})
+              urlencode(query_string)
         return url
 
     @property
@@ -333,7 +340,7 @@ class PartnerCredentials(PublicCredentials):
                  callback_uri=None, verified=False,
                  oauth_token=None, oauth_token_secret=None,
                  oauth_expires_at=None, oauth_authorization_expires_at=None,
-                 oauth_session_handle=None):
+                 oauth_session_handle=None, scope=None):
         """Construct the auth instance.
 
         Must provide the consumer key and secret.
@@ -348,6 +355,7 @@ class PartnerCredentials(PublicCredentials):
         self._oauth = None
         self.oauth_expires_at = oauth_expires_at
         self.oauth_authorization_expires_at = oauth_authorization_expires_at
+        self.scope = scope
 
         self._signature_method = SIGNATURE_RSA
         self.base_url = XERO_PARTNER_BASE_URL

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -45,6 +45,8 @@ class BaseManager(object):
         'OpeningBalanceDate',
         'PaymentDueDate',
         'ReportingDate',
+        'DeliveryDate',
+        'ExpectedArrivalDate',
     )
     BOOLEAN_FIELDS = (
         'IsSupplier',
@@ -65,6 +67,7 @@ class BaseManager(object):
         'HasAttachments',
         'ShowOnCashBasisReports',
         'IncludeInEmails',
+        'SentToContact',
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
Purchase orders have been added to the Xero API. http://developer.xero.com/documentation/api/purchase-orders/

This PR adds the Purchase Order endpoint, and updates the hardcoded list of date/boolean fields to include field names that are new in purchase order objects.