### PR TITLE
Fix incorrect field parsing with filters

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -326,6 +326,7 @@ class BaseManager(object):
                     elif parts[1] in ["isnull"]:
                         sign = '=' if value else '!'
                         return '%s%s=null' % (parts[0], sign)
+                    field = field.replace('_', '.')
                 return fmt % (
                     field,
                     get_filter_params(key, value)


### PR DESCRIPTION
Eg. for 
`invoices.filter(Contact_Name__contains='some_text')`
the resulting query fragment was:
`Contact_Name.contains("some_text")` ,
when it should've been:
`Contact.Name.contains("some_text")`
