### PR TITLE
Add 'Tracking' as a plural of 'TrackingCategory'

### DIFF
--- a/xero/utils.py
+++ b/xero/utils.py
@@ -43,6 +43,7 @@ OBJECT_NAMES = {
     "Reports": "Report",
     "TaxRates": "TaxRate",
     "TrackingCategories": "TrackingCategory",
+    "Tracking": "TrackingCategory",
     "Users": "User",
     "Associations": "Association",
     "Files": "File",


### PR DESCRIPTION
This feels a bit uncomfortable, but effectively; the Xero API is inconsistent about using 'TrackingCategories' as the key for elements where it expects the sub-elements to be 'TrackingCategory'. Specifically, for LineItems, it uses the term 'Tracking' instead, as per https://developer.xero.com/documentation/api/invoices/

So, this adds 'Tracking' as a "plural" version of "TrackingCategory", to allow inserting line items with tracked options enabled. Without this, creating invoices fails with `PostDataInvalidException: Object reference not set to an instance of an object. []`