### PR TITLE
Add object name mapping for TaxComponents

### DIFF
--- a/xero/__init__.py
+++ b/xero/__init__.py
@@ -1,4 +1,4 @@
 from .api import Xero
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 

--- a/xero/utils.py
+++ b/xero/utils.py
@@ -41,6 +41,7 @@ OBJECT_NAMES = {
     "Receipts": "Receipt",
     "RepeatingInvoices": "RepeatingInvoice",
     "Reports": "Report",
+    "TaxComponents": "TaxComponent",
     "TaxRates": "TaxRate",
     "TrackingCategories": "TrackingCategory",
     "Tracking": "TrackingCategory",


### PR DESCRIPTION
We had an error being thrown when trying to push up some tax rates to Xero. Turns out the XML wasn't being generated correctly. Adding an entry for TaxComponents to the OBJECT_NAMES mapping dictionary solved this.