### PR TITLE
Handle case where weird date timestamps are sent from Xero

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -61,6 +61,15 @@ class UtilsTest(unittest.TestCase):
             {'date': None}
         )
 
+        # Weird Date output from Xero
+        example_input = {
+            'date': '/Date(0+0000)/',
+        }
+
+        self.assertEqual(
+            xero.utils.json_load_object_hook(example_input),
+            {'date': '/Date(0+0000)/'}
+        )
 
     def test_parse_date(self):
         """ Tests of the parse_date input formats.
@@ -98,5 +107,11 @@ class UtilsTest(unittest.TestCase):
         # Not a date
         self.assertEqual(
             xero.utils.parse_date('not a date'),
+            None
+        )
+
+        # Weird Date output from Xero
+        self.assertEqual(
+            xero.utils.parse_date('/Date(0+0000)/'),
             None
         )

--- a/xero/utils.py
+++ b/xero/utils.py
@@ -88,6 +88,11 @@ def parse_date(string, force_datetime=False):
     if len(values) > 3 or force_datetime:
         return datetime.datetime(**values)
 
+    # Sometimes Xero returns Date(0+0000), so we end up with no
+    # values. Return None for this case
+    if not values:
+        return None
+
     return datetime.date(**values)
 
 


### PR DESCRIPTION
I had a user that was getting this sort of Date object being returned from Xero:

`"DateOfBirth": "\/Date(0+0000)\/",`

This was breaking pyxero's JSON date parsing. This commit handles the case where no values could be obtained from the Date parsing. I wasn't sure of proceeding this way, or perhaps just handling the case where the timestamp is 0, but this way should stop exceptions being raised if a date or datetime object can not be created.