### PR TITLE
Add PurchaseOrder to OBJECT_NAMES map

### DIFF
--- a/xero/utils.py
+++ b/xero/utils.py
@@ -52,6 +52,7 @@ OBJECT_NAMES = {
     "Inbox": "Inbox",
     "LineItems": "LineItem",
     "JournalLines": "JournalLine",
+    "PurchaseOrders": "PurchaseOrder",
 }
 
 def isplural(word):


### PR DESCRIPTION
Required for PurchaseOrder API.