### PR TITLE
Add 'CanApplyToRevenue' to boolean fields constant so filter is applied correctly

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -280,6 +280,18 @@ class ManagerTest(unittest.TestCase):
             {'where': 'Name.ToLower()=="test contact"&&Status=="VOIDED"'}
         )
 
+    def test_boolean_filter(self):
+        """The filter function should correctly handle various arguments"""
+        credentials = Mock(base_url="")
+        manager = Manager('invoices', credentials)
+        uri, params, method, body, headers, singleobject = manager._filter(
+            CanApplyToRevenue=True
+        )
+        self.assertEqual(
+            params,
+            {'where': 'CanApplyToRevenue==true'}
+        )
+
     def test_magnitude_filters(self):
         """The filter function should correctlu handle date arguments and gt, lt operators"""
         credentials = Mock(base_url="")

--- a/xero/__init__.py
+++ b/xero/__init__.py
@@ -1,4 +1,4 @@
 from .api import Xero
 
-__version__ = "0.8.1"
+__version__ = "0.8.2"
 

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -69,6 +69,7 @@ class BaseManager(object):
         'ShowOnCashBasisReports',
         'IncludeInEmails',
         'SentToContact',
+        'CanApplyToRevenue',
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
pyxero did not handle this boolean correctly in the filter so was sending through "True" as a string instead of sending true