### PR TITLE
Added 'where' to list of filter params

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -341,7 +341,7 @@ class BaseManager(object):
                 )
 
             # Move any known parameter names to the query string
-            KNOWN_PARAMETERS = ['order', 'offset', 'page', 'includeArchived']
+            KNOWN_PARAMETERS = ['order', 'offset', 'page', 'includeArchived', 'where']
             for param in KNOWN_PARAMETERS:
                 if param in kwargs:
                     params[param] = kwargs.pop(param)


### PR DESCRIPTION
According to the documentation [here](https://developer.xero.com/documentation/api/requests-and-responses/#title4), there's a "where" parameter.

Enabling this parameter permits you to do things like the following:
`xero.invoices.filter(where='Contact.ContactID = Guid("cd7094ea-eb31-47fa-b11c-a1d4efaf27ba")')`