### PR TITLE
Revert pyxero version to current one on PyPi.

### DIFF
--- a/xero/__init__.py
+++ b/xero/__init__.py
@@ -1,4 +1,4 @@
 from .api import Xero
 
-__version__ = "0.8.2"
+__version__ = "0.8.0"
 


### PR DESCRIPTION
We should update this version when we tag/release on PyPi, not really before.