### PR TITLE
XeroNotImplemented is returning JSON, not XML

### DIFF
--- a/xero/exceptions.py
+++ b/xero/exceptions.py
@@ -91,11 +91,11 @@ class XeroNotImplemented(XeroException):
     # HTTP 501
     def __init__(self, response):
         # Extract the useful error message from the text.
-        # parseString takes byte content, not unicode.
-        dom = parseString(response.text.encode(response.encoding))
-        messages = dom.getElementsByTagName('Message')
+        msg = None
+        if response.headers['content-type'].startswith('application/json'):
+            data = json.loads(response.text)
+            msg = data.get('Message', None)
 
-        msg = messages[0].childNodes[0].data
         super(XeroNotImplemented, self).__init__(response, msg)
 
 


### PR DESCRIPTION
Found that this was blowing up because the Xero API returns JSON here, not XML.  Fixed to parse the JSON instead.