### PR TITLE
Correct the number of "other issues"

### DIFF
--- a/xero/exceptions.py
+++ b/xero/exceptions.py
@@ -29,7 +29,7 @@ class XeroBadRequest(XeroException):
                 self.problem = self.errors[0]
                 if len(self.errors) > 1:
                     msg += ' (%s, and %s other issues)' % (
-                            self.problem, len(self.errors))
+                            self.problem, len(self.errors) - 1)
                 else:
                     msg += ' (%s)' % self.problem
             else:


### PR DESCRIPTION
At the moment, if you get a set of validation errors which look like this:

```
"ValidationErrors": [
  {
    "Message": "The TaxType field is mandatory"
  },
  {
    "Message": "Account code must be specified"
  }
],
```

You will receive the following error message:

```
xero.exceptions.XeroBadRequest: ValidationException: A validation exception occurred (The TaxType field is mandatory, and 2 other issues)
```

Due to the fact that the exception handler takes the first error in the list to use as the reason text and then counts the total number of errors to show in the "and X other issues", the X value will always be one higher than it should be - because in this case there's only 1 other issue, the first one is being counted twice.