### PR TITLE
Added Item fields to BaseManager.BOOLEAN_FIELDS

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -72,7 +72,10 @@ class BaseManager(object):
         'CanApplyToRevenue',
         'IsReconciled',
         'EnablePaymentsToAccount',
-        'ShowInExpenseClaims'
+        'ShowInExpenseClaims',
+        'IsTrackedAsInventory',
+        'IsSold',
+        'IsPurchased',
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
Add additional boolean fields for Items to prevent the error:
 ``xero.exceptions.XeroBadRequest: PostDataInvalidException: The string 'False' is not a valid Boolean value.``