### PR TITLE
Raise Xero exception when API response unparseable

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -7,6 +7,7 @@ import six
 from datetime import datetime
 from six.moves.urllib.parse import parse_qs
 from xml.etree.ElementTree import tostring, SubElement, Element
+from xml.parsers.expat import ExpatError
 
 from .exceptions import (
     XeroBadRequest, XeroExceptionUnknown, XeroForbidden, XeroInternalError,
@@ -199,7 +200,11 @@ class BaseManager(object):
                 return response.content
 
             elif response.status_code == 400:
-                raise XeroBadRequest(response)
+                try:
+                    raise XeroBadRequest(response)
+                except (ValueError, ExpatError):
+                    raise XeroExceptionUnknown(
+                        response, msg='Unable to parse Xero API response')
 
             elif response.status_code == 401:
                 raise XeroUnauthorized(response)


### PR DESCRIPTION
If you `put` an invoice/creditnote/etc, and there's an error, the API
response can be malformed such that it cannot be parsed. (For example,
if the response is very large, the API server appears to truncate HTTP
responses to _exactly_ 1 MB.)

As it is, pyxero will attempt to raise a `XeroBadRequest`, but fails
when parsing the http response, so the parser error gets raised
instead (e.g. `ValueError` if JSON). This makes it difficult to see what
the original error response was from outside the pyxero code.

Instead, it should raise with `XeroExceptionUnknown` so that at least the
original http response is passed in the exception, and thus is visible
elsewhere in the stack.