### PR TITLE
Fix for AmountPaid field incorrectly being treated as ID field

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -267,6 +267,14 @@ class ManagerTest(unittest.TestCase):
             {'where': 'Contact.ContactID==Guid("3e776c4b-ea9e-4bb1-96be-6b0c7a71a37f")'}
         )
 
+        uri, params, method, body, headers, singleobject = manager._filter(
+                **{'AmountPaid': 0.0})
+
+        self.assertEqual(
+            params,
+            {'where': 'AmountPaid=="0.0"'}
+        )
+
     def test_rawfilter(self):
         """The filter function should correctly handle various arguments"""
         credentials = Mock(base_url="")

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -309,7 +309,7 @@ class BaseManager(object):
 
             def get_filter_params(key, value):
                 last_key = key.split('_')[-1]
-                if last_key.upper().endswith('ID'):
+                if last_key.endswith('ID'):
                     return 'Guid("%s")' % six.text_type(value)
                 if key in self.BOOLEAN_FIELDS:
                     return 'true' if value else 'false'


### PR DESCRIPTION
The 'AmountPaid' field on invoices was being incorrectly treated
as an ID field. This change means that only fields ending in "ID" are treated
as GUID fields. Fixes #200 