### PR TITLE
'LinkedTransactions' are a relatively new Xero API endpoint

### DIFF
--- a/xero/api.py
+++ b/xero/api.py
@@ -23,6 +23,7 @@ class Xero(object):
         "Invoices",
         "Items",
         "Journals",
+        "LinkedTransactions",
         "ManualJournals",
         "Organisations",
         "Overpayments",


### PR DESCRIPTION
This 'LinkedTransaction' endpoint allows things like assigning an expense to a customer.

https://developer.xero.com/documentation/api/linked-transactions

It's not currently implemented in this client library (or either of the Ruby ones for that matter). I had alook at the design of PyXero and it's cleverly built in a metaprogramming style, so I figured I would give it a go simply adding `LinkedTransaction` to the `OBJECT_LIST` in `api.py` so that this endpoint can be accessed, and see how that went.

The tests pass and some of the regular PyXero API works, for example:

* `xero.linkedtransactions.all()` returns a list of dicts which are recognisable as Xero LinkedTransaction entities.

* `xero.linkedtransactions.get('<known-valid-linked-transaction-id>')` returns a single LinkedTransaction

Unfortunately, the other methods such as `filter` don't seem to work (although this could be something I'm doing wrong with the filter parameter I'm passing??)

for example:
* `xero.linkedtransactions.filter(SourceTransactionID=<known-valid-source-transaction-id>)` returns the same list as `xero.linkedtransactions.all()` without filtering it.

For the volumes of work I need to do I can get by with pulling everything and filtering locally, but it would be nice to have this endpoint working.

I've submitted a PR but I'd understand if it's not mergable as-is, and would be happy to discuss further how to fix.
