### PR TITLE
return response from put_attachment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist
 build
 _build
 distribute-*
+.venv
+.idea

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -286,8 +286,7 @@ class BaseManager(object):
 
     def put_attachment(self, id, filename, file, content_type, include_online=False):
         """Upload an attachment to the Xero object (from file object)."""
-        self.put_attachment_data(id, filename, file.read(), content_type,
-                                 include_online=include_online)
+        return self.put_attachment_data(id, filename, file.read(), content_type, include_online=include_online)
 
     def prepare_filtering_date(self, val):
         if isinstance(val, datetime):


### PR DESCRIPTION
Feature request
============

When dealing with attachments it is useful to be able to store certain variables from the response without making extra calls to the API to find those values (One such value is the attachment id). 

Solution
======

This pull request returns the response from the call that `put_attachment` makes so that the user can get access to such values.

