### PR TITLE
Add DiscountEnteredAsPercent to BOOLEAN_FIELDS

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -73,7 +73,7 @@ class BaseManager(object):
         'IsReconciled',
         'EnablePaymentsToAccount',
         'ShowInExpenseClaims',
-        'DiscountEnteredAsPercent'
+        'DiscountEnteredAsPercent',
     )
     DECIMAL_FIELDS = (
         'Hours',

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -72,7 +72,8 @@ class BaseManager(object):
         'CanApplyToRevenue',
         'IsReconciled',
         'EnablePaymentsToAccount',
-        'ShowInExpenseClaims'
+        'ShowInExpenseClaims',
+        'DiscountEnteredAsPercent'
     )
     DECIMAL_FIELDS = (
         'Hours',


### PR DESCRIPTION
Xero appear to have added an extra element `DiscountEnteredAsPercent` to the `LineItems` element of `Invoices`: https://community.xero.com/developer/discussion/96548634

It's undocumented at the time of writing: https://developer.xero.com/documentation/api/invoices#LineItems

I've only been able to make this appear when making a GET request against the `Invoices` endpoint using something like `invoices.filter(InvoiceNumber='INV-0123', page=1)`; using `invoices.filter(InvoiceNumber='INV-0123')` without the page number does not return that element.

In any case, adding `DiscountEnteredAsPercent` to `BOOLEAN_FIELDS` makes sense here, and does make this problem go away in my testing.