### PR TITLE
Add Super Funds to Payroll API

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Within the payrollAPI you have access to:
 * payrollcalendars
 * payruns
 * payslip
+* superfunds
 * timesheets
 
 

--- a/xero/api.py
+++ b/xero/api.py
@@ -75,6 +75,7 @@ class Payroll(object):
 
     OBJECT_LIST = (
         "Employees",
+        "SuperFunds",
         "Timesheets",
         "PayItems",
         "PayRuns",


### PR DESCRIPTION
The super fund object type is currently missing from the Payroll API.  This commit fixes that.

This PR also resolves https://github.com/freakboy3742/pyxero/issues/244 which was abandoned by the submitter.

