### PR TITLE
Add additional invoice specific endpoints

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -28,6 +28,10 @@ class BaseManager(object):
         'get_attachment_data',
         'put_attachment_data',
     )
+    OBJECT_DECORATED_METHODS = {
+            'Invoices' : ['email', 'online_invoice'],
+    }
+
     DATETIME_FIELDS = (
         'UpdatedDateUTC',
         'Updated',
@@ -259,6 +263,14 @@ class BaseManager(object):
         file.write(data)
         return len(data)
 
+    def _email(self, id):
+        uri = '/'.join([self.base_url, self.name, id, 'Email'])
+        return uri, {}, 'post', None, None, True
+
+    def _online_invoice(self, id):
+        uri = '/'.join([self.base_url, self.name, id, 'OnlineInvoice'])
+        return uri, {}, 'get', None, None, True
+    
     def save_or_put(self, data, method='post', headers=None, summarize_errors=True):
         uri = '/'.join([self.base_url, self.name])
         body = {'xml': self._prepare_data_for_save(data)}

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -331,7 +331,7 @@ class BaseManager(object):
                         fmt = ''.join(['%s.', parts[1], '(%s)'])
                     elif parts[1] in ["tolower", "toupper"]:
                         field = parts[0]
-                        fmt = ''.join(['%s.', parts[1], '==%s'])
+                        fmt = ''.join(['%s.', parts[1], '()==%s'])
                     elif parts[1] in self.OPERATOR_MAPPINGS:
                         field = parts[0]
                         key = field

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -329,6 +329,9 @@ class BaseManager(object):
                     if parts[1] in ["contains", "startswith", "endswith"]:
                         field = parts[0]
                         fmt = ''.join(['%s.', parts[1], '(%s)'])
+                    elif parts[1] in ["tolower", "toupper"]:
+                        field = parts[0]
+                        fmt = ''.join(['%s.', parts[1], '==%s'])
                     elif parts[1] in self.OPERATOR_MAPPINGS:
                         field = parts[0]
                         key = field

--- a/xero/manager.py
+++ b/xero/manager.py
@@ -25,3 +25,9 @@ class Manager(BaseManager):
         for method_name in self.DECORATED_METHODS:
             method = getattr(self, '_%s' % method_name)
             setattr(self, method_name, self._get_data(method))
+
+        if self.name in self.OBJECT_DECORATED_METHODS.keys():
+            object_decorated_methods = self.OBJECT_DECORATED_METHODS[self.name]
+            for method_name in object_decorated_methods:
+                method = getattr(self, '_%s' % method_name)
+                setattr(self, method_name, self._get_data(method))


### PR DESCRIPTION
Xero Invoices is a great feature for billing customers. We particularly like the ability to template the invoice PDF generation and to trigger an invoice email to the customer. This PR add support to do all of this directly via PyXero.

As the `_email` and `_online_invoice` methods are specific to the Invoices endpoint, we though it made sense to add an `OBJECT_DECORATED_METHODS` dict that implements endpoint specific methods, rather than the generic `DECORATED_METHODS`. Happy to change this if the maintainers don't agree with this approach.

Also adding the ability to filter using `tolower` and `toupper`. We were running into an issue trying to look for existing contacts and not finding them do to case sensitivity. 

Summary of new features:
- Emailing an invoice: https://developer.xero.com/documentation/api/invoices#email
- Retrieving the online invoice url: https://developer.xero.com/documentation/api/invoices#onlineinvoice
- Filtering using tolower and toupper. E.g. contact names

Thanks go to the maintainers for this project!