### PR TITLE
Travis failing to install dateutil for Python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       sudo: true
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
-install: python setup.py install
+install:
+  - pip install "setuptools>=40"
+  - python setup.py install
 # command to run tests, e.g. python setup.py test
 script: python setup.py test


### PR DESCRIPTION
The error is caused by dateutil having version 0.0.0 after being installed. 
```
Running python-dateutil-2.8.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-y1ymqv0f/python-dateutil-2.8.1/egg-dist-tmp-g8qrc4h8
...
Adding python-dateutil 0.0.0 to easy-install.pth file
```