### PR TITLE
Fix to saving an updated invoice

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -107,6 +107,7 @@ class BaseManager(object):
         "DateString",
         "HasErrors",
         "DueDateString",
+        "HasAccount",
     )
     OPERATOR_MAPPINGS = {
         "gt": ">",


### PR DESCRIPTION
It seems xero has a new field in invoices called HasAccount but doesn't
want this to be uploaded in the API? Don't send when saving changes.

see issue GH-103