### PR TITLE
Implement filter by ids

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -255,7 +255,7 @@ class ManagerTest(unittest.TestCase):
         manager = Manager("contacts", credentials)
 
         uri, params, method, body, headers, singleobject = manager._filter(
-            IDs=["1","2","3","4","5"]
+            IDs=["1", "2", "3", "4", "5"]
         )
 
         self.assertEqual(method, "get")

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -255,7 +255,7 @@ class ManagerTest(unittest.TestCase):
         manager = Manager("contacts", credentials)
 
         uri, params, method, body, headers, singleobject = manager._filter(
-            IDs="1,2,3,4,5"
+            IDs=["1","2","3","4","5"]
         )
 
         self.assertEqual(method, "get")

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -249,6 +249,23 @@ class ManagerTest(unittest.TestCase):
 
         self.assertEqual(params, {"where": 'AmountPaid=="0.0"'})
 
+    def test_filter(self):
+        """The filter function should correctly handle various arguments"""
+        credentials = Mock(base_url="")
+        manager = Manager("contacts", credentials)
+
+        uri, params, method, body, headers, singleobject = manager._filter(
+            IDs="1,2,3,4,5"
+        )
+
+        self.assertEqual(method, "get")
+        self.assertFalse(singleobject)
+
+        expected_params = {
+            "IDs": "1,2,3,4,5"
+        }
+        self.assertEqual(params, expected_params)
+
     def test_rawfilter(self):
         """The filter function should correctly handle various arguments"""
         credentials = Mock(base_url="")

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -249,7 +249,7 @@ class ManagerTest(unittest.TestCase):
 
         self.assertEqual(params, {"where": 'AmountPaid=="0.0"'})
 
-    def test_filter(self):
+    def test_filter_ids(self):
         """The filter function should correctly handle various arguments"""
         credentials = Mock(base_url="")
         manager = Manager("contacts", credentials)

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -374,6 +374,11 @@ class BaseManager(object):
                 headers = self.prepare_filtering_date(val)
                 del kwargs["since"]
 
+            # Accept IDs parameter for Invoices and Contacts endpoints
+            if "IDs" in kwargs:
+                params["IDs"] = kwargs["IDs"]
+                del kwargs["IDs"]
+
             def get_filter_params(key, value):
                 last_key = key.split("_")[-1]
                 if last_key.endswith("ID"):

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -376,7 +376,7 @@ class BaseManager(object):
 
             # Accept IDs parameter for Invoices and Contacts endpoints
             if "IDs" in kwargs:
-                params["IDs"] = kwargs["IDs"]
+                params["IDs"] = ",".join(kwargs["IDs"])
                 del kwargs["IDs"]
 
             def get_filter_params(key, value):


### PR DESCRIPTION
Requested by: #267 
Xero offers a fast way to select multiple invoices by using the `IDs` param. This has been added to the `_filter` method.

[https://developer.xero.com/documentation/api/requests-and-responses](https://developer.xero.com/documentation/api/requests-and-responses)

Usage:
```
xero.invoices.filter(IDs='f3ecf55f-b7b0-47d2-a0f3-97df84890af2,f3ecf55f-b7b0-47d2-a0f3-97df84890af2f3ecf55f-b7b0-47d2-a0f3-97df84890af2')
```