### PR TITLE
Use XML body format instead of form encoding

### DIFF
--- a/tests/manager.py
+++ b/tests/manager.py
@@ -372,7 +372,7 @@ class ManagerTest(unittest.TestCase):
         except XeroExceptionUnknown:
             pass
 
-        call = request.mock_calls[0]  
+        call = request.mock_calls[0]
         self.assertTrue(call.kwargs["headers"]["Content-Type"], "application/xml")
 
     def test_request_body_format(self):
@@ -382,7 +382,7 @@ class ManagerTest(unittest.TestCase):
         # Default used when no user_agent set on manager and credentials has nothing to offer.
         credentials = Mock(base_url="", user_agent=None)
         manager = Manager("reports", credentials)
-        
-        body = manager.save_or_put({"bing": "bong"})[3] 
+
+        body = manager.save_or_put({"bing": "bong"})[3]
 
         self.assertTrue(body, "<Invoice><bing>bong</bing></Invoice>")

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -5,10 +5,11 @@ import re
 import six
 import unittest
 from collections import defaultdict
-from mock import Mock
+from mock import Mock, patch
 from xml.dom.minidom import parseString
 
 from xero.manager import Manager
+from xero.exceptions import XeroExceptionUnknown
 
 
 class ManagerTest(unittest.TestCase):
@@ -357,3 +358,31 @@ class ManagerTest(unittest.TestCase):
         credentials = Mock(base_url="", user_agent="MY_COMPANY-MY_CONSUMER_KEY")
         manager = Manager("reports", credentials, user_agent="DemoCompany-1234567890")
         self.assertEqual(manager.user_agent, "DemoCompany-1234567890")
+
+    @patch("xero.basemanager.requests.post")
+    def test_request_content_type(self, request):
+        """The Content-Type should be application/xml
+        """
+
+        # Default used when no user_agent set on manager and credentials has nothing to offer.
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("reports", credentials)
+        try:
+            manager._get_data(lambda: ("_", {}, "post", {}, {}, True))()
+        except XeroExceptionUnknown:
+            pass
+
+        call = request.mock_calls[0]  
+        self.assertTrue(call.kwargs["headers"]["Content-Type"], "application/xml")
+
+    def test_request_body_format(self):
+        """The body content should be in valid XML format
+        """
+
+        # Default used when no user_agent set on manager and credentials has nothing to offer.
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("reports", credentials)
+        
+        body = manager.save_or_put({"bing": "bong"})[3] 
+
+        self.assertTrue(body, "<Invoice><bing>bong</bing></Invoice>")

--- a/tests/manager.py
+++ b/tests/manager.py
@@ -8,8 +8,8 @@ from collections import defaultdict
 from mock import Mock, patch
 from xml.dom.minidom import parseString
 
-from xero.manager import Manager
 from xero.exceptions import XeroExceptionUnknown
+from xero.manager import Manager
 
 
 class ManagerTest(unittest.TestCase):

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -197,6 +197,8 @@ class BaseManager(object):
             if headers is None:
                 headers = {}
 
+            headers["Content-Type"] = "application/xml"
+
             if isinstance(self.credentials, OAuth2Credentials):
                 if self.credentials.tenant_id:
                     headers["Xero-tenant-id"] = self.credentials.tenant_id
@@ -312,7 +314,7 @@ class BaseManager(object):
 
     def save_or_put(self, data, method="post", headers=None, summarize_errors=True):
         uri = "/".join([self.base_url, self.name])
-        body = {"xml": self._prepare_data_for_save(data)}
+        body = self._prepare_data_for_save(data)
         params = self.extra_params.copy()
         if not summarize_errors:
             params["summarizeErrors"] = "false"


### PR DESCRIPTION
This wrapper gets a 500 error when submitting `POST` requests to Payroll API because it submits the body of the request as an XML string in the `application/x-www-form-encoded` format. 

As outlined by Xero support below, the Payroll API does not support this format and requires XML or JSON. Since we are converting dictionaries to XML anyway, we may as well update `save_or_put` to submit the full XML in the body of the request and supply an `application/xml` header.

<img src="https://i.imgur.com/W8wecGbl.png"/>