### PR TITLE
Add payment services endpoint.

### DIFF
--- a/xero/api.py
+++ b/xero/api.py
@@ -28,6 +28,7 @@ class Xero(object):
         "ManualJournals",
         "Organisations",
         "Overpayments",
+        "PaymentServices",
         "Payments",
         "Prepayments",
         "PurchaseOrders",


### PR DESCRIPTION
A Xero endpoint isn't available in the list. I am just adding it.

See: https://developer.xero.com/documentation/api/payment-services