### PR TITLE
Support passing an optional authorisation event id to get_tenants.

### DIFF
--- a/tests/auth.py
+++ b/tests/auth.py
@@ -527,6 +527,8 @@ class OAuth2CredentialsTest(unittest.TestCase):
         self.assertEqual(
             tenants, [{"id": "1", "tenantId": "12345", "tenantType": "ORGANISATION"}]
         )
+        tenants = credentials.get_tenants(auth_event_id="b71db552-68ff-4d80-a824-7544e5ccad28")
+        self.assertEqual(r_get.mock_calls[-1].args[0].split('?authEventId=')[1], "b71db552-68ff-4d80-a824-7544e5ccad28")
 
     @patch("xero.auth.OAuth2Credentials.get_tenants")
     def test_set_default_tenant(self, get_tenants):

--- a/xero/auth.py
+++ b/xero/auth.py
@@ -637,11 +637,17 @@ class OAuth2Credentials(object):
         self._init_oauth(token)
         return token
 
-    def get_tenants(self):
+    def get_tenants(self, auth_event_id=None):
         """
         Get the list of tenants (Xero Organisations) to which this token grants access.
+
+        Optionally, you may pass a UUID as auth_event_id that will be used to limit to
+        only those tenants that were authorised in that authorisation event.
         """
         connection_url = self.base_url + XERO_OAUTH2_CONNECTIONS_URL
+
+        if auth_event_id:
+            connection_url += '?authEventId=' + auth_event_id
 
         response = requests.get(connection_url, auth=self.oauth, headers=self.headers)
         if response.status_code == 200:


### PR DESCRIPTION
This enables fetching only a list of tenants that were authorised in the specified event.