### PR TITLE
Handle 429 Too Many Requests

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -256,6 +256,10 @@ class BaseManager(object):
             elif response.status_code == 404:
                 raise XeroNotFound(response)
 
+            elif response.status_code == 429:
+                payload = "Reason: " + response.headers.get("X-Rate-Limit-Problem")
+                raise XeroRateLimitExceeded(response, payload)
+
             elif response.status_code == 500:
                 raise XeroInternalError(response)
 

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -257,7 +257,8 @@ class BaseManager(object):
                 raise XeroNotFound(response)
 
             elif response.status_code == 429:
-                payload = "Reason: " + response.headers.get("X-Rate-Limit-Problem")
+                limit_reason = response.headers.get("X-Rate-Limit-Problem") or ""
+                payload = {"oauth_problem": ["rate limit exceeded: " + limit_reason],"oauth_problem_advice":["please wait before retrying the xero api", "The limit exceeded is: " + limit_reason]}
                 raise XeroRateLimitExceeded(response, payload)
 
             elif response.status_code == 500:

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -257,7 +257,7 @@ class BaseManager(object):
                 raise XeroNotFound(response)
 
             elif response.status_code == 429:
-                limit_reason = response.headers.get("X-Rate-Limit-Problem") or ""
+                limit_reason = response.headers.get("X-Rate-Limit-Problem") or "unknown"
                 payload = {"oauth_problem": ["rate limit exceeded: " + limit_reason],"oauth_problem_advice":["please wait before retrying the xero api", "The limit exceeded is: " + limit_reason]}
                 raise XeroRateLimitExceeded(response, payload)
 


### PR DESCRIPTION
response 429 is used for daily API limit exceeded. Fixes #313 