### PR TITLE
Update Known Parameters based on Endpoint

### DIFF
--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -41,6 +41,25 @@ class BaseManager(object):
     OBJECT_DECORATED_METHODS = {
         "Invoices": ["email", "online_invoice"],
     }
+
+    KNOWN_PARAMETERS = {
+        # "Budgets": ["DateFrom", "DateTo", "IDs"],
+        # "Contacts": ["IDs"],
+        # "Invoices": [
+        #     "ContactIDs", "createdByMyApp", "IDs", "InvoiceNumbers",
+        #     "Statuses", "summaryOnly"],
+        # "Journals": ["paymentsOnly"],
+        # "LinkedTransactions": [
+        #     "ContactID", "LinkedTransactionID", "SourceTransactionID",
+        #     "Status", "TargetTransactionID"],
+        # "PurchaseOrders": [
+        #     "DateFrom", "DateTo", "Status"],
+        "Quotes": [
+            "ContactID", "DateFrom", "DateTo", "ExpiryDateFrom",
+            "ExpiryDateTo", "QuoteNumber", "Status"],
+        # "TaxRates": ["TaxType"],
+    }
+
     DATETIME_FIELDS = (
         "UpdatedDateUTC",
         "Updated",
@@ -197,7 +216,8 @@ class BaseManager(object):
         def wrapper(*args, **kwargs):
             timeout = kwargs.pop("timeout", None)
 
-            uri, params, method, body, headers, singleobject = func(*args, **kwargs)
+            uri, params, method, body, headers, singleobject = func(
+                *args, **kwargs)
 
             if headers is None:
                 headers = {}
@@ -257,7 +277,8 @@ class BaseManager(object):
                 raise XeroNotFound(response)
 
             elif response.status_code == 429:
-                limit_reason = response.headers.get("X-Rate-Limit-Problem") or "unknown"
+                limit_reason = response.headers.get(
+                    "X-Rate-Limit-Problem") or "unknown"
                 payload = {"oauth_problem": ["rate limit exceeded: " + limit_reason],
                            "oauth_problem_advice": ["please wait before retrying the xero api",
                                                     "The limit exceeded is: " + limit_reason]}
@@ -361,7 +382,8 @@ class BaseManager(object):
         """Upload an attachment to the Xero object."""
         uri = "/".join([self.base_url, self.name, id, "Attachments", filename])
         params = {"IncludeOnline": "true"} if include_online else {}
-        headers = {"Content-Type": content_type, "Content-Length": str(len(data))}
+        headers = {"Content-Type": content_type,
+                   "Content-Length": str(len(data))}
         return uri, params, "put", data, headers, False
 
     def put_attachment(self, id, filename, file, content_type, include_online=False):

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -452,7 +452,9 @@ class BaseManager(object):
                 return fmt % (field, get_filter_params(key, value))
 
             # Move any known parameter names to the query string
-            KNOWN_PARAMETERS = ["order", "offset", "page", "includeArchived"]
+            KNOWN_PARAMETERS = ["order", "offset", "page",
+                                "includeArchived"] + self.KNOWN_PARAMETERS[self.name]
+
             for param in KNOWN_PARAMETERS:
                 if param in kwargs:
                     params[param] = kwargs.pop(param)

--- a/xero/basemanager.py
+++ b/xero/basemanager.py
@@ -52,8 +52,8 @@ class BaseManager(object):
         # "LinkedTransactions": [
         #     "ContactID", "LinkedTransactionID", "SourceTransactionID",
         #     "Status", "TargetTransactionID"],
-        # "PurchaseOrders": [
-        #     "DateFrom", "DateTo", "Status"],
+        "PurchaseOrders": [
+            "DateFrom", "DateTo", "Status"],
         "Quotes": [
             "ContactID", "DateFrom", "DateTo", "ExpiryDateFrom",
             "ExpiryDateTo", "QuoteNumber", "Status"],


### PR DESCRIPTION
I've updated the Known Parameters feature so we can add additional query parameters that should exist outside of the `where` parameter. Usage will be as follows:

`xero.quotes.filter(ContactID=1111111)` will translate to `api.xero.com/api.xro/2.0/Quotes?ContactID=1111111`

I've only added Quotes (for my need) and PurchaseOrders (to fix https://github.com/freakboy3742/pyxero/issues/246).

If someone has the bandwidth to test with the rest, I have added the rest, but commented out so theres no potential for conflict.