### PR TITLE
Actions fixes for currently available python versions

### DIFF
--- a/.github/workflows/build_status.yml
+++ b/.github/workflows/build_status.yml
@@ -6,14 +6,14 @@ on:
 
 jobs:
   smoke:
-    name: Smoke test (3.5)
+    name: Smoke test (3.6)
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         pip install --upgrade pip 
@@ -25,15 +25,15 @@ jobs:
         isort -c
 
   smoke:
-    name: Smoke test (3.5)
+    name: Smoke test (3.6)
     needs: precheck
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.5
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.6
     - name: Install dependencies
       run: |
         pip install --upgrade pip 
@@ -50,7 +50,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         flake8
     - name: isort
       run: |
-        isort -c
+        isort -c .
 
   smoke:
     name: Smoke test (3.6)

--- a/examples/partner_oauth_flow/runserver.py
+++ b/examples/partner_oauth_flow/runserver.py
@@ -1,7 +1,8 @@
 import os
+import sys
+
 import SimpleHTTPServer
 import SocketServer
-import sys
 from StringIO import StringIO
 from urlparse import parse_qsl, urlparse
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,9 @@ max-line-length = 88
 [isort]
 sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
 default_section = THIRDPARTY
-known_standard_library = mock,requests,six
+extra_standard_library = mock,requests,six
 known_first_party = xero
 multi_line_output = 3
 line_length = 88
 indent = 4
 include_trailing_comma = True
-not_skip = __init__.py


### PR DESCRIPTION
This moves the smoke tests and CQ test to python3.6 since it's the earliest available in Github.

Python3.6 also brings with it isort 5.x , so there are some additional fixes to update the configuration etc, as per the sort upgrade guidelines.