### PR TITLE
Add config to pass on token scope-change warnings

### DIFF
--- a/xero/auth.py
+++ b/xero/auth.py
@@ -491,6 +491,7 @@ class OAuth2Credentials(object):
         scope=None,
         tenant_id=None,
         user_agent=None,
+        relax_token_scope=False,
     ):
         from xero import __version__ as VERSION
 
@@ -566,7 +567,12 @@ class OAuth2Credentials(object):
         # Various different exceptions may be raised, so pass the exception
         # through as XeroAccessDenied
         except Exception as e:
-            raise XeroAccessDenied(e)
+            # oauthlib raises a warning when returned token scope
+            # is different from the client scope
+            if self.relax_token_scope && isinstance(e, Warning):
+                session.token = e.token
+            else:
+                raise XeroAccessDenied(e)
         self._init_oauth(token)
 
     def generate_url(self):


### PR DESCRIPTION
This provides a more-explicit fix for #287

* we call `requests_oauthlib.OAuth2Session#fetch_token` which
  * [calls `oauthlib.oauth2.WebApplicationClient#parse_request_body_response`](https://github.com/requests/requests-oauthlib/blob/3a2a852e33c691c7e793300ce366a01b6e4b3848/requests_oauthlib/oauth2_session.py#L388) which
    * is actually `oauthlib.oauth2.rfc6749.clients.Client#parse_request_body_response` which 
      * [calls `oauthlib.oauth2.rfc6749.parameters.parse_token_response`](https://github.com/oauthlib/oauthlib/blob/6569ec3c062be7268f4a17f5a371aa29f1bcfa4a/oauthlib/oauth2/rfc6749/clients/base.py#L427) which 
        * [emits a `Warning` on changed scopes](https://github.com/oauthlib/oauthlib/commit/ca4811b3087f9d34754d3debf839e247593b8a39#diff-27d6ecb53c0926bcd8cc87f98cf661d5e2936cd48b04f57cdfdb63cd3b23ab38R400-R406), complete with the parsed token 
        * sets `self.token` * [calls `self.populate_token_attributes`](https://github.com/oauthlib/oauthlib/blob/6569ec3c062be7268f4a17f5a371aa29f1bcfa4a/oauthlib/oauth2/rfc6749/clients/base.py#L428)
    * sets `self.token` which
      * [sets the WebApplicationClient's token again, and calls its `populate_token_attributes` again](https://github.com/requests/requests-oauthlib/blob/3a2a852e33c691c7e793300ce366a01b6e4b3848/requests_oauthlib/oauth2_session.py#L142-L145)
  * returns `self.token`


Since we get exactly the same token in the warning, and the [original commit's message](https://github.com/oauthlib/oauthlib/commit/ca4811b3087f9d34754d3debf839e247593b8a39#) suggests the warning is optional, it seems as though we can just do `session.token = e.token` (whose setter calls the necessary follow-on logic) and continue as usual.