### PR TITLE
Update README.md as WSGIRequest.get_raw_uri() is obselete

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ def start_xero_auth_view(request):
 def process_callback_view(request):
     cred_state = caches['mycache'].get('xero_creds')
     credentials = OAuth2Credentials(**cred_state)
-    auth_secret = request.get_raw_uri()
+    auth_secret = request.build_absolute_uri()
     credentials.verify(auth_secret)
     credentials.set_default_tenant()
     caches['mycache'].set('xero_creds', credentials.state)


### PR DESCRIPTION
``WSGIRequest.get_raw_uri()`` is no longer available in Django. ``WSGIRequest.build_absolute_uri()`` was the more appropriate method.

https://code.djangoproject.com/ticket/32698