### PR TITLE
update XeroUnauthorized to handle json response

### DIFF
--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -75,12 +75,11 @@ class XeroUnauthorized(XeroException):
             self.problem = self.errors[0]
             super().__init__(response, payload["oauth_problem_advice"][0])
         elif response.headers["content-type"].startswith("application/json"):
-            data = response.json()
-            msg_info = data.get("Detail", "") or data.get("Message", "")
-            msg = "{}: {}".format(data["Type"], msg_info)
+            data = json.loads(response.text)
+            msg = data.get("Detail", "")
             self.errors = [msg.split(":")[0]]
             self.problem = self.errors[0]
-            super().__init__(response, msg_info)
+            super().__init__(response, msg)
 
 
 class XeroForbidden(XeroException):

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -69,17 +69,17 @@ class XeroBadRequest(XeroException):
 class XeroUnauthorized(XeroException):
     # HTTP 401: Unauthorized
     def __init__(self, response):
-        if response.headers["content-type"].startswith("text/html"):
-            payload = parse_qs(response.text)
-            self.errors = [payload["oauth_problem"][0]]
-            self.problem = self.errors[0]
-            super().__init__(response, payload["oauth_problem_advice"][0])
-        elif response.headers["content-type"].startswith("application/json"):
+        if response.headers["content-type"].startswith("application/json"):
             data = json.loads(response.text)
             msg = data.get("Detail", "")
             self.errors = [msg.split(":")[0]]
             self.problem = self.errors[0]
             super().__init__(response, msg)
+        else:
+            payload = parse_qs(response.text)
+            self.errors = [payload["oauth_problem"][0]]
+            self.problem = self.errors[0]
+            super().__init__(response, payload["oauth_problem_advice"][0])
 
 
 class XeroForbidden(XeroException):

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -78,7 +78,7 @@ class XeroUnauthorized(XeroException):
             data = response.json()
             msg_info = data.get("Detail", "") or data.get("Message", "")
             msg = "{}: {}".format(data["Type"], msg_info)
-            self.errors = [msg]
+            self.errors = [msg.split(":")[0]]
             self.problem = self.errors[0]
             super().__init__(response, msg_info)
 

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -69,10 +69,19 @@ class XeroBadRequest(XeroException):
 class XeroUnauthorized(XeroException):
     # HTTP 401: Unauthorized
     def __init__(self, response):
-        payload = parse_qs(response.text)
-        self.errors = [payload["oauth_problem"][0]]
-        self.problem = self.errors[0]
-        super().__init__(response, payload["oauth_problem_advice"][0])
+        print(response.text)
+        if response.headers["content-type"].startswith("text/html"):
+            payload = parse_qs(response.text)
+            self.errors = [payload["oauth_problem"][0]]
+            self.problem = self.errors[0]
+            super().__init__(response, payload["oauth_problem_advice"][0])
+        elif response.headers["content-type"].startswith("application/json"):
+            data = response.json()
+            msg_info = data.get("Detail", "") or data.get("Message", "")
+            msg = "{}: {}".format(data["Type"], msg_info)
+            self.errors = [msg]
+            self.problems = self.errors[0]
+            super().__init__(response, self.problems)
 
 
 class XeroForbidden(XeroException):

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -79,8 +79,8 @@ class XeroUnauthorized(XeroException):
             msg_info = data.get("Detail", "") or data.get("Message", "")
             msg = "{}: {}".format(data["Type"], msg_info)
             self.errors = [msg]
-            self.problems = self.errors[0]
-            super().__init__(response, self.problems)
+            self.problem = self.errors[0]
+            super().__init__(response, msg_info)
 
 
 class XeroForbidden(XeroException):

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -69,7 +69,6 @@ class XeroBadRequest(XeroException):
 class XeroUnauthorized(XeroException):
     # HTTP 401: Unauthorized
     def __init__(self, response):
-        print(response.text)
         if response.headers["content-type"].startswith("text/html"):
             payload = parse_qs(response.text)
             self.errors = [payload["oauth_problem"][0]]

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -30,7 +30,9 @@ class PublicCredentialsTest(unittest.TestCase):
     def test_initial_constructor(self, r_post):
         "Initial construction causes a request to get a request token"
         r_post.return_value = Mock(
-            status_code=200, text="oauth_token=token&oauth_token_secret=token_secret"
+            status_code=200,
+            text="oauth_token=token&oauth_token_secret=token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PublicCredentials(
@@ -64,6 +66,7 @@ class PublicCredentialsTest(unittest.TestCase):
         r_post.return_value = Mock(
             status_code=401,
             text="oauth_problem=consumer_key_unknown&oauth_problem_advice=Consumer%20key%20was%20not%20recognised",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         with self.assertRaises(XeroUnauthorized):
@@ -127,7 +130,9 @@ class PublicCredentialsTest(unittest.TestCase):
     def test_url(self, r_post):
         "The request token URL can be obtained"
         r_post.return_value = Mock(
-            status_code=200, text="oauth_token=token&oauth_token_secret=token_secret"
+            status_code=200,
+            text="oauth_token=token&oauth_token_secret=token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PublicCredentials(consumer_key="key", consumer_secret="secret")
@@ -140,7 +145,9 @@ class PublicCredentialsTest(unittest.TestCase):
     def test_url_with_scope(self, r_post):
         "The request token URL includes the scope parameter"
         r_post.return_value = Mock(
-            status_code=200, text="oauth_token=token&oauth_token_secret=token_secret"
+            status_code=200,
+            text="oauth_token=token&oauth_token_secret=token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PublicCredentials(
@@ -153,7 +160,9 @@ class PublicCredentialsTest(unittest.TestCase):
     def test_configurable_url(self, r_post):
         "Test configurable API url"
         r_post.return_value = Mock(
-            status_code=200, text="oauth_token=token&oauth_token_secret=token_secret"
+            status_code=200,
+            text="oauth_token=token&oauth_token_secret=token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         url = "https//api-tls.xero.com"
@@ -170,6 +179,7 @@ class PublicCredentialsTest(unittest.TestCase):
         r_post.return_value = Mock(
             status_code=200,
             text="oauth_token=verified_token&oauth_token_secret=verified_token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PublicCredentials(
@@ -212,6 +222,7 @@ class PublicCredentialsTest(unittest.TestCase):
         r_post.return_value = Mock(
             status_code=401,
             text="oauth_problem=bad_verifier&oauth_problem_advice=The consumer was denied access to this resource.",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PublicCredentials(
@@ -256,7 +267,9 @@ class PartnerCredentialsTest(unittest.TestCase):
     def test_initial_constructor(self, r_post):
         "Initial construction causes a request to get a request token"
         r_post.return_value = Mock(
-            status_code=200, text="oauth_token=token&oauth_token_secret=token_secret"
+            status_code=200,
+            text="oauth_token=token&oauth_token_secret=token_secret",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PartnerCredentials(
@@ -293,6 +306,7 @@ class PartnerCredentialsTest(unittest.TestCase):
         r_post.return_value = Mock(
             status_code=200,
             text="oauth_token=token2&oauth_token_secret=token_secret2&oauth_session_handle=session",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = PartnerCredentials(
@@ -329,6 +343,7 @@ class PartnerCredentialsTest(unittest.TestCase):
         r_post.return_value = Mock(
             status_code=200,
             text="oauth_token=token&oauth_token_secret=token_secret&oauth_session_handle=session",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         url = "https//api-tls.xero.com"

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -180,7 +180,7 @@ class ExceptionsTest(unittest.TestCase):
         r_get.return_value = Mock(
             status_code=401,
             text="oauth_problem=token_expired&oauth_problem_advice=The%20access%20token%20has%20expired",
-            headers=head
+            headers=head,
         )
 
         credentials = Mock(base_url="")
@@ -203,7 +203,7 @@ class ExceptionsTest(unittest.TestCase):
             )
         except Exception as e:
             self.fail("Should raise a XeroUnauthorized, not %s" % e)
-            
+
     @patch("requests.get")
     def test_unauthorized_expired_json(self, r_get):
         "A session with an expired token raises an unauthorized exception"
@@ -213,7 +213,7 @@ class ExceptionsTest(unittest.TestCase):
         r_get.return_value = Mock(
             status_code=401,
             text='{"Type":null,"Title":"Unauthorized","Status":401,"Detail":"TokenExpired: token expired at 01/01/2001 00:00:00"}',
-            headers=head
+            headers=head,
         )
 
         credentials = Mock(base_url="")
@@ -225,7 +225,9 @@ class ExceptionsTest(unittest.TestCase):
 
         except XeroUnauthorized as e:
             # Error messages have been extracted
-            self.assertEqual(str(e), "TokenExpired: token expired at 01/01/2001 00:00:00")
+            self.assertEqual(
+                str(e), "TokenExpired: token expired at 01/01/2001 00:00:00"
+            )
             self.assertEqual(e.errors[0], "TokenExpired")
 
             # The response has also been stored

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -23,13 +23,11 @@ class ExceptionsTest(unittest.TestCase):
     def test_bad_request(self, r_put):
         "Data with validation errors raises a bad request exception"
         # Verified response from the live API
-        head = dict()
-        head["content-type"] = "text/xml; charset=utf-8"
         r_put.return_value = Mock(
             status_code=400,
             encoding="utf-8",
             text=mock_data.bad_request_text,
-            headers=head,
+            headers={"content-type": "text/xml; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -74,13 +72,14 @@ class ExceptionsTest(unittest.TestCase):
     @patch("requests.put")
     def test_bad_request_invalid_response(self, r_put):
         "If the error response from the backend is malformed (or truncated), raise a XeroExceptionUnknown"
-        head = {"content-type": "text/xml; charset=utf-8"}
-
         # Same error as before, but the response got cut off prematurely
         bad_response = mock_data.bad_request_text[:1000]
 
         r_put.return_value = Mock(
-            status_code=400, encoding="utf-8", text=bad_response, headers=head
+            status_code=400,
+            encoding="utf-8",
+            text=bad_response,
+            headers={"content-type": "text/xml; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -109,12 +108,10 @@ class ExceptionsTest(unittest.TestCase):
     def test_unregistered_app(self, r_get):
         "An app without a signature raises a BadRequest exception, but with HTML payload"
         # Verified response from the live API
-        head = dict()
-        head["content-type"] = "text/html; charset=utf-8"
         r_get.return_value = Mock(
             status_code=400,
             text="oauth_problem=signature_method_rejected&oauth_problem_advice=No%20certificates%20have%20been%20registered%20for%20the%20consumer",
-            headers=head,
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -148,6 +145,7 @@ class ExceptionsTest(unittest.TestCase):
         r_get.return_value = Mock(
             status_code=401,
             text="oauth_problem=signature_invalid&oauth_problem_advice=Failed%20to%20validate%20signature",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -175,12 +173,10 @@ class ExceptionsTest(unittest.TestCase):
     def test_unauthorized_expired_text(self, r_get):
         "A session with an expired token raises an unauthorized exception"
         # Verified response from the live API
-        head = dict()
-        head["content-type"] = "text/html; charset=utf-8"
         r_get.return_value = Mock(
             status_code=401,
             text="oauth_problem=token_expired&oauth_problem_advice=The%20access%20token%20has%20expired",
-            headers=head,
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -208,12 +204,10 @@ class ExceptionsTest(unittest.TestCase):
     def test_unauthorized_expired_json(self, r_get):
         "A session with an expired token raises an unauthorized exception"
         # Verified response from the live API
-        head = dict()
-        head["content-type"] = "application/json; charset=utf-8"
         r_get.return_value = Mock(
             status_code=401,
             text='{"Type":null,"Title":"Unauthorized","Status":401,"Detail":"TokenExpired: token expired at 01/01/2001 00:00:00"}',
-            headers=head,
+            headers={"content-type": "application/json; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -244,7 +238,9 @@ class ExceptionsTest(unittest.TestCase):
         "In case of an SSL failure, a Forbidden exception is raised"
         # This is unconfirmed; haven't been able to verify this response from API.
         r_get.return_value = Mock(
-            status_code=403, text="The client SSL certificate was not valid."
+            status_code=403,
+            text="The client SSL certificate was not valid.",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -271,7 +267,9 @@ class ExceptionsTest(unittest.TestCase):
         "If you request an object that doesn't exist, a Not Found exception is raised"
         # Verified response from the live API
         r_get.return_value = Mock(
-            status_code=404, text="The resource you're looking for cannot be found"
+            status_code=404,
+            text="The resource you're looking for cannot be found",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -299,7 +297,10 @@ class ExceptionsTest(unittest.TestCase):
         # Response based off Xero documentation; not confirmed by reality.
         r_get.return_value = Mock(
             status_code=429,
-            headers={"X-Rate-Limit-Problem": "day"},
+            headers={
+                "X-Rate-Limit-Problem": "day",
+                "content-type": "text/html; charset=utf-8",
+            },
             text="oauth_problem=rate%20limit%20exceeded&oauth_problem_advice=please%20wait%20before%20retrying%20the%20xero%20api",
         )
 
@@ -334,6 +335,7 @@ class ExceptionsTest(unittest.TestCase):
         r_get.return_value = Mock(
             status_code=500,
             text="An unhandled error with the Xero API occurred. Contact the Xero API team if problems persist.",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -364,7 +366,10 @@ class ExceptionsTest(unittest.TestCase):
         "In case of an SSL failure, a Forbidden exception is raised"
         # Verified response from the live API
         r_post.return_value = Mock(
-            status_code=501, encoding="utf-8", text=mock_data.not_implemented_text
+            status_code=501,
+            encoding="utf-8",
+            text=mock_data.not_implemented_text,
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -391,6 +396,7 @@ class ExceptionsTest(unittest.TestCase):
         r_get.return_value = Mock(
             status_code=503,
             text="oauth_problem=rate%20limit%20exceeded&oauth_problem_advice=please%20wait%20before%20retrying%20the%20xero%20api",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")
@@ -419,7 +425,9 @@ class ExceptionsTest(unittest.TestCase):
         "If Xero goes down for maintenance, an exception is raised"
         # Response based off Xero documentation; not confirmed by reality.
         r_get.return_value = Mock(
-            status_code=503, text="The Xero API is currently offline for maintenance"
+            status_code=503,
+            text="The Xero API is currently offline for maintenance",
+            headers={"content-type": "text/html; charset=utf-8"},
         )
 
         credentials = Mock(base_url="")

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -226,7 +226,7 @@ class ExceptionsTest(unittest.TestCase):
         except XeroUnauthorized as e:
             # Error messages have been extracted
             self.assertEqual(str(e), "TokenExpired: token expired at 01/01/2001 00:00:00")
-            self.assertEqual(e.errors[0], "token_expired")
+            self.assertEqual(e.errors[0], "TokenExpired")
 
             # The response has also been stored
             self.assertEqual(e.response.status_code, 401)


### PR DESCRIPTION
Added json handling to XeroUnauthorized for response on a 401 status that looks like this
`{"Type":null,"Title":"Unauthorized","Status":401,"Detail":"TokenExpired: token expired at 04/09/2023 05:16:59","Instance":"6489df60-8891-470e-9268-a9a43f5da71e","Extensions":{}}`
The Exception itself was erroring so it was falling through to a normal Exception