### PR TITLE
Fix superfluous JSON/XML tagging in PaymentManager

### DIFF
--- a/src/xero/paymentmanager.py
+++ b/src/xero/paymentmanager.py
@@ -21,5 +21,5 @@ class PaymentManager(BaseManager):
     def _delete(self, id):
         uri = "/".join([self.base_url, self.name, id])
         data = {"Status": "DELETED"}
-        body = {"xml": self._prepare_data_for_save(data)}
+        body = self._prepare_data_for_save(data)
         return uri, {}, "post", body, None, False

--- a/tests/test_paymentmanager.py
+++ b/tests/test_paymentmanager.py
@@ -21,8 +21,7 @@ class ManagerTest(unittest.TestCase):
 
         self.assertEqual(params, {})
         self.assertEqual(method, "post")
-        self.assertIn("xml", body)
 
-        assertXMLEqual(self, body["xml"], "<Status>DELETED</Status>")
+        assertXMLEqual(self, body, "<Status>DELETED</Status>")
 
         self.assertIsNone(headers)


### PR DESCRIPTION
Hi team,

When testing payment deletions for a feature I am implementing for a live app ([batch2sepa](https://batch2sepa.eu/)), I noticed that the `PaymentManager._delete(self, id)` was adding in a wrapping dictionary. This makes the request body get processed as a query encoded string. Xero, granted, fails to parse the body and returns a 500:

<img width="640" alt="image" src="https://github.com/freakboy3742/pyxero/assets/11677504/8a1cf2b9-3570-4ba6-bb0f-b1d6dcf974a8">

I only noticed this after checking the app history, making the change in the attached commit leads to the issue being resolved and the payments being deleted correctly.

Let me know if you need any additional information. I hope this will get admitted swiftly!

Kind regards,

Evrim Öztamur