### PR TITLE
Drop Python 3.7 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12-dev"]
         include:
         - experimental: false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -30,7 +29,7 @@ long_description_content_type= text/markdown
 [options]
 zip_safe = False
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.8
 package_dir =
     = src
 install_requires =
@@ -41,12 +40,10 @@ install_requires =
     cryptography>=1.3.1  # As above, but fixes issue with missing module imports not picked up for some reason.
 
 [options.extras_require]
-# Extras used by developers *of* gbulb are pinned to specific versions to
+# Extras used by developers *of* pyxero are pinned to specific versions to
 # ensure environment consistency.
 dev =
-    # Pre-commit 3.0 dropped support for Python 3.7
-    pre-commit == 2.21.0; python_version < "3.8"
-    pre-commit == 3.0.2; python_version >= "3.8"
+    pre-commit == 3.0.2
     pytest == 7.2.1
     pytest-tldr == 0.2.5
     tox == 4.4.2

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py{37,38,39,310,311,312}
+envlist = py{38,39,310,311,312}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Py3.7 is EOL; no need to support it any longer.