### PR TITLE
Credit notes allocations support

### DIFF
--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -41,6 +41,7 @@ class BaseManager:
     OBJECT_DECORATED_METHODS = {
         "Invoices": ["email", "online_invoice"],
         "Organisations": ["actions"],
+        "CreditNotes": ["put_allocation", "delete_allocation"]
     }
     OBJECT_FILTER_FIELDS = {
         "Invoices": {
@@ -374,6 +375,15 @@ class BaseManager:
     def _actions(self):
         uri = "/".join([self.base_url, self.name, "Actions"])
         return uri, {}, "get", None, None, False
+
+    def _put_allocation(self, id, data):
+        uri = "/".join([self.base_url, self.name, id, "Allocations"])
+        body = json.dumps(data)
+        return uri, {}, "put", body, {"Content-Type": "application/json"}, True
+
+    def _delete_allocation(self, cn_id, allocation_id):
+        uri = "/".join([self.base_url, self.name, cn_id, "Allocations", allocation_id])
+        return uri, {}, "delete", None, None, True
 
     def save_or_put(self, data, method="post", headers=None, summarize_errors=True):
         uri = "/".join([self.base_url, self.name])

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -41,7 +41,7 @@ class BaseManager:
     OBJECT_DECORATED_METHODS = {
         "Invoices": ["email", "online_invoice"],
         "Organisations": ["actions"],
-        "CreditNotes": ["put_allocation", "delete_allocation"]
+        "CreditNotes": ["put_allocation", "delete_allocation"],
     }
     OBJECT_FILTER_FIELDS = {
         "Invoices": {
@@ -154,7 +154,7 @@ class BaseManager:
         "HasErrors",
         "DueDateString",
         "HasAccount",
-        "ID"
+        "ID",
     )
     OPERATOR_MAPPINGS = {
         "gt": ">",
@@ -379,7 +379,7 @@ class BaseManager:
 
     def _put_allocation(self, id, data):
         uri = "/".join([self.base_url, self.name, id, "Allocations"])
-        #body = json.dumps(data)
+        # body = json.dumps(data)
         root_elm = Element("Allocation")
         if "Amount" in data:
             data["AppliedAmount"] = data["Amount"]

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -379,7 +379,6 @@ class BaseManager:
 
     def _put_allocation(self, id, data):
         uri = "/".join([self.base_url, self.name, id, "Allocations"])
-        # body = json.dumps(data)
         root_elm = Element("Allocation")
         if "Amount" in data:
             data["AppliedAmount"] = data["Amount"]

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -154,6 +154,7 @@ class BaseManager:
         "HasErrors",
         "DueDateString",
         "HasAccount",
+        "ID"
     )
     OPERATOR_MAPPINGS = {
         "gt": ">",

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -378,8 +378,14 @@ class BaseManager:
 
     def _put_allocation(self, id, data):
         uri = "/".join([self.base_url, self.name, id, "Allocations"])
-        body = json.dumps(data)
-        return uri, {}, "put", body, {"Content-Type": "application/json"}, True
+        #body = json.dumps(data)
+        root_elm = Element("Allocation")
+        if "Amount" in data:
+            data["AppliedAmount"] = data["Amount"]
+            del data["Amount"]
+        self.dict_to_xml(root_elm, data)
+        body = tostring(root_elm)
+        return uri, {}, "put", body, None, False
 
     def _delete_allocation(self, cn_id, allocation_id):
         uri = "/".join([self.base_url, self.name, cn_id, "Allocations", allocation_id])


### PR DESCRIPTION
This fixes issue #374 .

Note that this is a quick fix to ensure basic functionality is available to manage credits notes allocations.
For more information about these, cf. https://developer.xero.com/documentation/api/accounting/creditnotes#allocating-creditnotes and https://developer.xero.com/documentation/api/accounting/creditnotes#deleting-creditnotes-allocations

Two decorators have been added to add / delete allocations:
- put_allocation
- delete_allocation

There is no direct "get" calls to obtain the list of credit allocations in the xero API, but the allocations are listed in the data returned when getting a credit note, e.g.
```python
allocations = xero.creditnotes.get(creditNoteID)[0]["Allocations"]
```

A few things to highlight:
- The "put_allocation" request encodes the request in xml to keep consistency. As xero is weirdly changing the "Amount" field name depending on whether we are using xml or json, I have added some automatic field transcribing.
- The returned elements are not properly parsed due to the mismatch between the manager name and the object being returned. But as it is already the case with other sub element (e.g. HistoryRecords) I suppose that's fine!
- It's not directly related, but I have noted during testing that xero sends the unknown field "ID" in CreditsNotes, so I have added it to the list of "NO_SEND_FIELDS" for convenience.