### PR TITLE
Manager .save() method should accept summarize_errors boolean

### DIFF
--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -399,8 +399,8 @@ class BaseManager:
             params["summarizeErrors"] = "false"
         return uri, params, method, body, headers, False
 
-    def _save(self, data):
-        return self.save_or_put(data, method="post")
+    def _save(self, data, summarize_errors=True):
+        return self.save_or_put(data, method="post", summarize_errors=summarize_errors)
 
     def _put(self, data, summarize_errors=True):
         return self.save_or_put(data, method="put", summarize_errors=summarize_errors)


### PR DESCRIPTION
PUT method on manager (eg: xero.invoices.put(foodata)) accepts summarize_errors boolean, but POST method (using .save()) does not. Xero API accepts this parameter on both PUT and POST.

I have modified BaseManager._save() to accept the field and pass it to the underlying mechanism to perform the request.