### PR TITLE
Support idempotent request

### DIFF
--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -29,7 +29,7 @@ class XeroBadRequest(XeroException):
     def __init__(self, response):
         if response.headers["content-type"].startswith("application/json"):
             data = json.loads(response.text)
-            msg = "{}: {}".format(data["Type"], data["Message"])
+            msg = f"{data['Type']}: {(data.get('Message') or 'No Message Provided')}"
             self.errors = [
                 err["Message"]
                 for elem in data.get("Elements", [])

--- a/src/xero/utils.py
+++ b/src/xero/utils.py
@@ -1,6 +1,7 @@
 import datetime
 import re
 import sys
+import uuid
 
 import requests
 
@@ -144,3 +145,21 @@ def resolve_user_agent(user_agent, default_override=None):
         or default_override
         or "pyxero/%s " % VERSION + requests.utils.default_user_agent()
     )
+
+
+def generate_idempotency_key() -> str:
+    """
+    Utility function to generate request idempotency keys
+    according to Xero's recommendation of generating 4
+    UUIDs and concatenating them
+
+    https://developer.xero.com/documentation/guides/idempotent-requests/idempotency/#getting-started
+
+    Use of this function is optional, providing an idempotency key to Xero
+    is not required, and the key can take any format, this just
+    follow's Xero's specific recommendation.
+
+    Returns:
+        str: A 128 character string made up of 4 concatenated UUIDs
+    """
+    return "".join([str(uuid.uuid4()) for _ in range(4)]).replace("-", "")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -99,3 +99,11 @@ class UtilsTest(unittest.TestCase):
 
         # Weird Date output from Xero
         self.assertEqual(xero.utils.parse_date("/Date(0+0000)/"), None)
+
+    def test_generate_idempotency_key(self):
+        key = xero.utils.generate_idempotency_key()
+
+        self.assertEqual(
+            len(key),
+            128
+        )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-""" Tests of the utils module. """
+"""Tests of the utils module."""
 
 import datetime
 import sys
@@ -103,7 +103,4 @@ class UtilsTest(unittest.TestCase):
     def test_generate_idempotency_key(self):
         key = xero.utils.generate_idempotency_key()
 
-        self.assertEqual(
-            len(key),
-            128
-        )
+        self.assertEqual(len(key), 128)


### PR DESCRIPTION
As requested in #328 

Add the ability to provide an idempotency key to methods which modify data, then send as a header to Xero.

https://developer.xero.com/documentation/guides/idempotent-requests/idempotency/

While adding this in I did some light type hinting in BaseManager to (hopefully) make it a bit clearer what some of these methods expect.