### PR TITLE
AddToWatchlist field on Account is boolean, not string.

### DIFF
--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -142,6 +142,7 @@ class BaseManager:
         "IsPurchased",
         "IsSold",
         "IsTrackedAsInventory",
+        "AddToWatchlist",
     )
     DECIMAL_FIELDS = (
         "Hours",


### PR DESCRIPTION
One of the causes of a validation error when trying to save an Account object. Doesn't solve all problems with this yet, I'm working on a more complicated fix to remove some other naughty fields, but this is at least one source of problems.