### PR TITLE
Expose response object with parsed data

### DIFF
--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -28,10 +28,8 @@ from .utils import isplural, json_load_object_hook, singular
 
 
 class XeroObjectList(list):
-    """
-    A list subclass that also carries the originating HTTP response, so callers
-    can reach response metadata (e.g. rate-limit headers).
-    """
+    """A list subclass that also carries the originating HTTP response, so callers can
+    reach response metadata (e.g. rate-limit headers)."""
 
     def __init__(self, data=(), *, response=None):
         super().__init__(data)

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -27,6 +27,17 @@ from .exceptions import (
 from .utils import isplural, json_load_object_hook, singular
 
 
+class XeroObjectList(list):
+    """
+    A list subclass that also carries the originating HTTP response, so callers
+    can reach response metadata (e.g. rate-limit headers).
+    """
+
+    def __init__(self, data=(), *, response=None):
+        super().__init__(data)
+        self.response = response
+
+
 class BaseManager:
     DECORATED_METHODS = (
         "get",
@@ -243,9 +254,13 @@ class BaseManager:
         )
 
         try:
-            return data[resource_name]
+            data = data[resource_name]
         except KeyError:
-            return data
+            pass
+
+        if isinstance(data, list):
+            return XeroObjectList(data, response=response)
+        return data
 
     def _get_data(self, func):
         """This is the decorator for our DECORATED_METHODS.

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,6 +1,6 @@
 import datetime
-import unittest
 import json
+import unittest
 from io import BytesIO
 from unittest.mock import Mock, patch
 
@@ -559,10 +559,8 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.get")
     def test_list_response_type(self, mock_get):
-        """
-        Responses should be instances of XeroObjectList
-        and also instances of list
-        """
+        """Responses should be instances of XeroObjectList and also instances of
+        list."""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -584,10 +582,8 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.get")
     def test_empty_list_response_type(self, mock_get):
-        """
-        Empty responses should be instances of XeroObjectList
-        and also instances of list
-        """
+        """Empty responses should be instances of XeroObjectList and also instances of
+        list."""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -609,9 +605,7 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.get")
     def test_list_response_behaves_like_list(self, mock_get):
-        """
-        Responses should behave like lists
-        """
+        """Responses should behave like lists."""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -655,10 +649,8 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.get")
     def test_list_response_carries_response_object(self, mock_get):
-        """
-        Xero list responses should carry the requests.response object
-        and expose the headers provided by Xero (in this case, Xero-Correlation-Id)
-        """
+        """Xero list responses should carry the requests.response object and expose the
+        headers provided by Xero (in this case, Xero-Correlation-Id)"""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -680,14 +672,15 @@ class ManagerTest(unittest.TestCase):
         self.assertTrue(hasattr(result.response, "headers"))
 
         # the headers should include the Xero Correlation ID from above
-        self.assertEqual(result.response.headers["Xero-Correlation-Id"], "5fe9659e-e5cc-4747-ad01-47adb038bf34")
+        self.assertEqual(
+            result.response.headers["Xero-Correlation-Id"],
+            "5fe9659e-e5cc-4747-ad01-47adb038bf34",
+        )
 
     @patch("xero.basemanager.requests.get")
     def test_empty_list_response_carries_response_object(self, mock_get):
-        """
-        Empty list responses should carry the requests.response object
-        and expose the headers provided by Xero (in this case, Xero-Correlation-Id)
-        """
+        """Empty list responses should carry the requests.response object and expose the
+        headers provided by Xero (in this case, Xero-Correlation-Id)"""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -709,4 +702,7 @@ class ManagerTest(unittest.TestCase):
         self.assertTrue(hasattr(result.response, "headers"))
 
         # the headers should include the Xero Correlation ID from above
-        self.assertEqual(result.response.headers["Xero-Correlation-Id"], "5fe9659e-e5cc-4747-ad01-47adb038bf34")
+        self.assertEqual(
+            result.response.headers["Xero-Correlation-Id"],
+            "5fe9659e-e5cc-4747-ad01-47adb038bf34",
+        )

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,8 +1,10 @@
 import datetime
 import unittest
+import json
 from io import BytesIO
 from unittest.mock import Mock, patch
 
+from xero.basemanager import XeroObjectList
 from xero.exceptions import XeroExceptionUnknown
 from xero.manager import Manager
 from xero.utils import generate_idempotency_key
@@ -554,3 +556,157 @@ class ManagerTest(unittest.TestCase):
 
         headers = mock_put.mock_calls[0][2]["headers"]
         self.assertEqual(headers["Idempotency-Key"], idempotency_key)
+
+    @patch("xero.basemanager.requests.get")
+    def test_list_response_type(self, mock_get):
+        """
+        Responses should be instances of XeroObjectList
+        and also instances of list
+        """
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text='{"Status": "OK", "Contacts": [{"Name": "A"}, {"Name": "B"}]}',
+            headers={
+                "content-type": "application/json",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Contacts", credentials)
+
+        result = manager.all()
+
+        # is instance of XeroObjectList
+        self.assertIsInstance(result, XeroObjectList)
+
+        # is also instance of list
+        self.assertIsInstance(result, list)
+
+    @patch("xero.basemanager.requests.get")
+    def test_empty_list_response_type(self, mock_get):
+        """
+        Empty responses should be instances of XeroObjectList
+        and also instances of list
+        """
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text='{"Status": "OK", "Contacts": []}',
+            headers={
+                "content-type": "application/json",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Contacts", credentials)
+
+        result = manager.all()
+
+        # is instance of XeroObjectList
+        self.assertIsInstance(result, XeroObjectList)
+
+        # is also instance of list
+        self.assertIsInstance(result, list)
+
+    @patch("xero.basemanager.requests.get")
+    def test_list_response_behaves_like_list(self, mock_get):
+        """
+        Responses should behave like lists
+        """
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text='{"Status": "OK", "Contacts": [{"Name": "A"}, {"Name": "B"}]}',
+            headers={
+                "content-type": "application/json",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Contacts", credentials)
+
+        result = manager.all()
+
+        # if it behaves like a list, it should equal a plain list of the same data
+        self.assertListEqual(result, [{"Name": "A"}, {"Name": "B"}])
+
+        # if it behaves like a list, we should be able to index it to get an item
+        self.assertEqual(result[1], {"Name": "B"})
+
+        # if it behaves like a list, we should be able to reverse it
+        reversed(result)
+
+        # if it behaves like a list, we should be able to sort it
+        sorted(result, key=lambda x: x["Name"])
+
+        # if it behaves like a list, we should be able to add it to another
+        self.assertListEqual(result + ["foo"], [{"Name": "A"}, {"Name": "B"}, "foo"])
+
+        # lists can't be keyed, so trying result["foo"] should raise TypeError
+        with self.assertRaises(TypeError):
+            result["foo"]
+
+        # if it behaves like a list, we should be able to append to it
+        result.append("foo")
+        self.assertListEqual(result, [{"Name": "A"}, {"Name": "B"}, "foo"])
+
+        # finally, we should be able to serialize it to JSON without
+        # a custom encoder (not quite true in the real world, since Xero objects
+        # have datetimes in them and these can't be serialized by default)
+        json.dumps(result)
+
+    @patch("xero.basemanager.requests.get")
+    def test_list_response_carries_response_object(self, mock_get):
+        """
+        Xero list responses should carry the requests.response object
+        and expose the headers provided by Xero (in this case, Xero-Correlation-Id)
+        """
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text='{"Status": "OK", "Contacts": [{"Name": "A"}, {"Name": "B"}]}',
+            headers={
+                "content-type": "application/json",
+                "Xero-Correlation-Id": "5fe9659e-e5cc-4747-ad01-47adb038bf34",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Contacts", credentials)
+
+        result = manager.all()
+
+        # the list should have a response attribute
+        self.assertTrue(hasattr(result, "response"))
+
+        # it should have headers
+        self.assertTrue(hasattr(result.response, "headers"))
+
+        # the headers should include the Xero Correlation ID from above
+        self.assertEqual(result.response.headers["Xero-Correlation-Id"], "5fe9659e-e5cc-4747-ad01-47adb038bf34")
+
+    @patch("xero.basemanager.requests.get")
+    def test_empty_list_response_carries_response_object(self, mock_get):
+        """
+        Empty list responses should carry the requests.response object
+        and expose the headers provided by Xero (in this case, Xero-Correlation-Id)
+        """
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text='{"Status": "OK", "Contacts": []}',
+            headers={
+                "content-type": "application/json",
+                "Xero-Correlation-Id": "5fe9659e-e5cc-4747-ad01-47adb038bf34",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Contacts", credentials)
+
+        result = manager.all()
+
+        # the list should have a response attribute
+        self.assertTrue(hasattr(result, "response"))
+
+        # it should have headers
+        self.assertTrue(hasattr(result.response, "headers"))
+
+        # the headers should include the Xero Correlation ID from above
+        self.assertEqual(result.response.headers["Xero-Correlation-Id"], "5fe9659e-e5cc-4747-ad01-47adb038bf34")


### PR DESCRIPTION
A change to wrap Xero responses in a custom list type that captures the response object and makes it available, while otherwise behaving like a vanilla list

Tests to confirm standard list behaviour (indexing, sorting, reversing, JSON serializing) to prevent API change

Solves:
https://github.com/freakboy3742/pyxero/issues/299
https://github.com/freakboy3742/pyxero/issues/289

Kind of solves:
https://github.com/freakboy3742/pyxero/issues/293 (exposes the remaining call limits BEFORE they are reached, by exposing the headers from the response)


Why a list subclass and now a custom type? Compatibility and no other reason. If there's a user out doing something that a list subclass can do that a custom class can't, I don't want to break their code. Yesterday you could take a response list from xero.invoices.all() and run it though `json.dumps(cls=DjangoJSONEncoder)`, you can still do that with this implementation (you'll just lose the request object along the way). If I'd written a totally custom class, anybody re-serializing would have had to make a change.


Tests have multiple assertions in the same test run, if you'd prefer I break these out I'm happy to but there's a lot of boilerplate to set the test up, so it made more sense to me to put all the "does it behave like a list?" tests in one thing instead of a lot of copy/paste.


```python
>>> response = xero.currencies.all()

>>> type(response)
xero.basemanager.XeroObjectList

>>> isinstance(response,list)
True

>>> print(response)
[{'Code': 'AUD', 'Description': 'Australian Dollar'}, ....] (truncated for brevity)

>>> type(response.response)
requests.models.Response

>>> response.response.headers["X-DayLimit-Remaining"]
'989'
```