### PR TITLE
Raise XeroUnexpectedResponse on non-JSON 200 responses for JSON-expecting calls

### DIFF
--- a/ChangeLog.rst
+++ b/ChangeLog.rst
@@ -6,6 +6,10 @@ ChangeLog
 master (unreleased)
 -------------------
 
+    #225 - Raise XeroUnexpectedResponse when a JSON-expecting call receives a
+           non-JSON 200 response (e.g. an HTML error page served with status 200),
+           instead of returning the raw body as if it were data.
+
 .. _v0.9.3:
 
 0.9.3 (2021-06-29)

--- a/README.md
+++ b/README.md
@@ -475,24 +475,19 @@ xero.invoices.save(invoice, idempotency_key=key)
 
 ### Unexpected responses
 
-Xero sometimes serves an HTML error page with a `200 OK` status. When that happens on
-a call that expects JSON data, pyxero raises `XeroUnexpectedResponse` instead of
-returning the HTML body as if it were your data:
+Xero sometimes serves an HTML error page with a `200 OK` status. When that happens on a call that expects JSON data, pyxero raises `XeroUnexpectedResponse` instead of returning the HTML body as if it were your data:
 
 ```python
 from xero.exceptions import XeroUnexpectedResponse
 
 try:
-    invoices = xero.invoices.filter(raw='AmountDue > 0')
+    invoices = xero.invoices.filter(raw="AmountDue > 0")
 except XeroUnexpectedResponse:
     # The server returned something other than JSON, usually an error page.
     ...
 ```
 
-Calls that legitimately fetch binary content are unaffected: PDFs requested via
-`headers={'Accept': 'application/pdf'}`, attachment downloads via `get_attachment_data()`,
-and `email()` all still return the raw bytes.
-
+Calls that legitimately fetch binary content are unaffected: PDFs requested via `headers={'Accept': 'application/pdf'}`, attachment downloads via `get_attachment_data()`, and `email()` all still return the raw bytes.
 
 ## Payroll
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,27 @@ The following will raise XeroBadRequest: None: No Message Provided
 xero.invoices.save(invoice, idempotency_key=key)
 ```
 
+### Unexpected responses
+
+Xero sometimes serves an HTML error page with a `200 OK` status. When that happens on
+a call that expects JSON data, pyxero raises `XeroUnexpectedResponse` instead of
+returning the HTML body as if it were your data:
+
+```python
+from xero.exceptions import XeroUnexpectedResponse
+
+try:
+    invoices = xero.invoices.filter(raw='AmountDue > 0')
+except XeroUnexpectedResponse:
+    # The server returned something other than JSON, usually an error page.
+    ...
+```
+
+Calls that legitimately fetch binary content are unaffected: PDFs requested via
+`headers={'Accept': 'application/pdf'}`, attachment downloads via `get_attachment_data()`,
+and `email()` all still return the raw bytes.
+
+
 ## Payroll
 
 In order to access the payroll methods from Xero, you can do it like this:

--- a/src/xero/basemanager.py
+++ b/src/xero/basemanager.py
@@ -23,6 +23,7 @@ from .exceptions import (
     XeroRateLimitExceeded,
     XeroTenantIdNotSet,
     XeroUnauthorized,
+    XeroUnexpectedResponse,
 )
 from .utils import isplural, json_load_object_hook, singular
 
@@ -319,9 +320,24 @@ class BaseManager:
             )
 
             if response.status_code == 200:
+                content_type = response.headers["content-type"]
                 # If we haven't got XML or JSON, assume we're being returned a
-                # binary file
-                if not response.headers["content-type"].startswith("application/json"):
+                # binary file. That assumption is only safe when the caller
+                # actually asked for a non-JSON representation (e.g.
+                # Accept: application/pdf for invoice PDFs, or the attachment
+                # download methods). When the caller expected JSON, an HTML
+                # error page served with a 200 status (issue #225) must raise
+                # instead of coming back as a bytestring.
+                if not content_type.startswith("application/json"):
+                    if headers.get("Accept", "").startswith("application/json"):
+                        raise XeroUnexpectedResponse(
+                            response,
+                            msg=(
+                                "Expected an 'application/json' response but the "
+                                f"server returned '{content_type}' with status 200. "
+                                "The body may be an HTML error page."
+                            ),
+                        )
                     return response.content
 
                 return self._parse_api_response(response, self.name)
@@ -396,7 +412,9 @@ class BaseManager:
     def _get_attachment_data(self, id, filename):
         """Retrieve the contents of a specific attachment (identified by filename)."""
         uri = f"{self.base_url}/{self.name}/{id}/Attachments/{filename}"
-        return uri, {}, "get", None, None, False
+        # Declare the binary representation so _get_data does not mistake an
+        # attachment download for an HTML error page (issue #225).
+        return uri, {}, "get", None, {"Accept": "application/octet-stream"}, False
 
     def get_attachment(self, id, filename, file):
         """Retrieve the contents of a specific attachment (identified by filename).
@@ -409,7 +427,8 @@ class BaseManager:
 
     def _email(self, id):
         uri = f"{self.base_url}/{self.name}/{id}/Email"
-        return uri, {}, "post", None, None, True
+        # The email endpoint returns the invoice as a PDF (issue #225).
+        return uri, {}, "post", None, {"Accept": "application/pdf"}, True
 
     def _online_invoice(self, id):
         uri = f"{self.base_url}/{self.name}/{id}/OnlineInvoice"

--- a/src/xero/exceptions.py
+++ b/src/xero/exceptions.py
@@ -138,6 +138,13 @@ class XeroNotAvailable(XeroException):
         super().__init__(response, response.text)
 
 
+class XeroUnexpectedResponse(XeroException):
+    # A 200 response arrived with a content type the endpoint never produces,
+    # typically an HTML error page served with a 200 status.
+    def __init__(self, response, msg=None):
+        super().__init__(response, msg)
+
+
 class XeroExceptionUnknown(XeroException):
     # Any other exception.
     pass

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -673,8 +673,8 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.get")
     def test_html_error_page_on_json_endpoint_raises(self, mock_get):
-        """A 200 response carrying an HTML error page should raise, not return
-        a bytestring (issue #225)."""
+        """A 200 response carrying an HTML error page should raise, not return a
+        bytestring (issue #225)."""
         mock_get.return_value = Mock(
             status_code=200,
             encoding="utf-8",
@@ -714,8 +714,8 @@ class ManagerTest(unittest.TestCase):
 
     @patch("xero.basemanager.requests.post")
     def test_email_still_returns_bytes(self, mock_post):
-        """The Invoices.email() convenience returns the PDF bytestring and must
-        not be affected."""
+        """The Invoices.email() convenience returns the PDF bytestring and must not be
+        affected."""
         payload = b"fake-email-pdf-bytes"
         mock_post.return_value = Mock(
             status_code=200,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -5,7 +5,7 @@ from io import BytesIO
 from unittest.mock import Mock, patch
 
 from xero.basemanager import XeroObjectList
-from xero.exceptions import XeroExceptionUnknown
+from xero.exceptions import XeroException, XeroExceptionUnknown, XeroUnexpectedResponse
 from xero.manager import Manager
 from xero.utils import generate_idempotency_key
 
@@ -670,6 +670,67 @@ class ManagerTest(unittest.TestCase):
             result.response.headers["Xero-Correlation-Id"],
             "5fe9659e-e5cc-4747-ad01-47adb038bf34",
         )
+
+    @patch("xero.basemanager.requests.get")
+    def test_html_error_page_on_json_endpoint_raises(self, mock_get):
+        """A 200 response carrying an HTML error page should raise, not return
+        a bytestring (issue #225)."""
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            text="﻿<!DOCTYPE html>\n<html lang=en>\n<title>Xero | Error</title>",
+            headers={
+                "content-type": "text/html; charset=utf-8",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Invoices", credentials)
+
+        with self.assertRaises(XeroUnexpectedResponse) as ctx:
+            manager.filter(raw="AmountDue > 0")
+
+        self.assertIsInstance(ctx.exception, XeroException)
+        self.assertIn("text/html", str(ctx.exception))
+        self.assertIn("application/json", str(ctx.exception))
+
+    @patch("xero.basemanager.requests.get")
+    def test_attachment_data_still_returns_bytes(self, mock_get):
+        """Binary downloads through get_attachment_data must keep working."""
+        payload = b"\x25\x50\x44\x46-fake-pdf-bytes"
+        mock_get.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            content=payload,
+            headers={
+                "content-type": "application/pdf",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Invoices", credentials)
+
+        result = manager.get_attachment_data(id="abc123", filename="invoice.pdf")
+
+        self.assertEqual(result, payload)
+
+    @patch("xero.basemanager.requests.post")
+    def test_email_still_returns_bytes(self, mock_post):
+        """The Invoices.email() convenience returns the PDF bytestring and must
+        not be affected."""
+        payload = b"fake-email-pdf-bytes"
+        mock_post.return_value = Mock(
+            status_code=200,
+            encoding="utf-8",
+            content=payload,
+            headers={
+                "content-type": "application/pdf",
+            },
+        )
+        credentials = Mock(base_url="", user_agent=None)
+        manager = Manager("Invoices", credentials)
+
+        result = manager.email(id="abc123")
+
+        self.assertEqual(result, payload)
 
     @patch("xero.basemanager.requests.get")
     def test_empty_list_response_carries_response_object(self, mock_get):


### PR DESCRIPTION
## Summary

Fixes #225.

Xero sometimes serves an HTML error page with a `200 OK` status (the issue reporter captured `b'\xef\xbb\xbf<!DOCTYPE html>... <title>Xero | Error 500</title>'` coming back from an invoice query). The `_get_data` wrapper returned any non-JSON body as raw bytes on the assumption it was a binary file, so JSON-expecting calls like `xero.invoices.filter()` silently handed the caller a bytestring. Downstream code then fails far from the cause, iterating over bytes instead of a list.

This PR makes the wrapper compare the response content type against what the caller actually asked for:

- If the request went out expecting JSON (`Accept: application/json`, which is also the wrapper's default) and a 200 arrives with any other content type, it now raises `XeroUnexpectedResponse` (new exception, subclass of `XeroException`), naming both content types in the message.
- Binary downloads keep working unchanged:
  - `_get_attachment_data` now declares `Accept: application/octet-stream`
  - `_email` declares `Accept: application/pdf` (its endpoint returns the invoice PDF)
  - explicit PDF fetches via `headers={'Accept': 'application/pdf'}` were already passing their own Accept header and are unaffected
- `PayrollManager` reuses `_get_data`; all its endpoints are JSON APIs, so it gains the same protection.

## Testing

- Added `test_html_error_page_on_json_endpoint_raises`: reproduces the issue (fails on main, raises after the fix).
- Added `test_attachment_data_still_returns_bytes` and `test_email_still_returns_bytes`: guard the binary download paths.
- Full suite locally: **82 passed, 1 failed** - the one failure is pre-existing on `main` on Windows (`test_upload_file_as_path`, WinError 32 file-locking between `setUp`/`tearDown`), unrelated to this change.
- `ruff check` and `ruff format --check` clean at the pinned CI version (0.16.0).

## Notes

- README gained a short "Unexpected responses" section documenting the new exception; ChangeLog updated under master (unreleased) per repo convention.
- The maintainer comment on #225 suggested "a way to enforce data type" - this implements that via the existing Accept header rather than adding a new parameter, since the header already carries caller intent for every documented binary path.